### PR TITLE
[SecurityUpdate] mxnet training docker 1.8 py3 cu110 Dockerfile.gpu

### DIFF
--- a/mxnet/training/docker/1.8/py3/cu110/Dockerfile.gpu.os_scan_allowlist.json
+++ b/mxnet/training/docker/1.8/py3/cu110/Dockerfile.gpu.os_scan_allowlist.json
@@ -1,0 +1,4959 @@
+{
+    "apparmor": [
+        {
+            "name": "CVE-2016-1585",
+            "description": "In all versions of AppArmor mount rules are accidentally widened when compiled.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-1585",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.10.95-0ubuntu2.11"
+                },
+                {
+                    "key": "package_name",
+                    "value": "apparmor"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "apparmor",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Deferred"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "no fix as of 2020-10-19"
+                    ]
+                }
+            ]
+        }
+    ],
+    "apt": [
+        {
+            "name": "CVE-2020-27350",
+            "description": "APT had several integer overflows and underflows while parsing .deb packages, aka GHSL-2020-168 GHSL-2020-169, in files apt-pkg/contrib/extracttar.cc, apt-pkg/deb/debfile.cc, and apt-pkg/contrib/arfile.cc. This issue affects: apt 1.2.32ubuntu0 versions prior to 1.2.32ubuntu0.2; 1.6.12ubuntu0 versions prior to 1.6.12ubuntu0.2; 2.0.2ubuntu0 versions prior to 2.0.2ubuntu0.2; 2.1.10ubuntu0 versions prior to 2.1.10ubuntu0.1;",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-27350",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "1.2.32ubuntu0.1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "apt"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:L/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "4.6"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "apt",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.0.2ubuntu0.2)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (1.6.12ubuntu0.2)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (1.2.32ubuntu0.2)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (1.0.1ubuntu2.24+esm3)"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "avahi": [
+        {
+            "name": "CVE-2021-3468",
+            "description": "A flaw was found in avahi in versions 0.6 up to 0.8. The event used to signal the termination of the client connection on the avahi Unix socket is not correctly handled in the client_work function, allowing a local attacker to trigger an infinite loop. The highest threat from this vulnerability is to the availability of the avahi service, which becomes unresponsive after this flaw is triggered.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3468",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.6.32~rc+dfsg-1ubuntu2.3"
+                },
+                {
+                    "key": "package_name",
+                    "value": "avahi"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:L/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "2.1"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "avahi",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (0.8-5ubuntu3)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (0.7-4ubuntu7.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (0.7-3.1ubuntu1.3)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (0.6.32~rc+dfsg-1ubuntu2.3+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (0.6.31-4ubuntu1.3+esm1)"
+                            ],
+                            [
+                                "Patches:",
+                                "Other:"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "as of 2021-07-06, the proposed patch has not been commited\nupstream"
+                    ]
+                }
+            ]
+        }
+    ],
+    "binutils": [
+        {
+            "name": "CVE-2019-14250",
+            "description": "An issue was discovered in GNU libiberty, as distributed in GNU Binutils 2.32. simple_object_elf_match in simple-object-elf.c does not check for a zero shstrndx value, leading to an integer overflow and resultant heap-based buffer overflow.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-14250",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.26.1-1ubuntu1~16.04.8"
+                },
+                {
+                    "key": "package_name",
+                    "value": "binutils"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "4.3"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "binutils",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.33)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.30-21ubuntu1~18.04.3)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.26.1-1ubuntu1~16.04.8+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needs triage"
+                            ],
+                            [
+                                "Patches:",
+                                "Other: Vendor:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2019-14444",
+            "description": "apply_relocations in readelf.c in GNU Binutils 2.32 contains an integer overflow that allows attackers to trigger a write access violation (in byte_put_little_endian function in elfcomm.c) via an ELF file, as demonstrated by readelf.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-14444",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.26.1-1ubuntu1~16.04.8"
+                },
+                {
+                    "key": "package_name",
+                    "value": "binutils"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "4.3"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "binutils",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.32.51.20190813-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.30-21ubuntu1~18.04.3)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.26.1-1ubuntu1~16.04.8+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2019-17451",
+            "description": "An issue was discovered in the Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils 2.32. It is an integer overflow leading to a SEGV in _bfd_dwarf2_find_nearest_line in dwarf2.c, as demonstrated by nm.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17451",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.26.1-1ubuntu1~16.04.8"
+                },
+                {
+                    "key": "package_name",
+                    "value": "binutils"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "4.3"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "binutils",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.30-21ubuntu1~18.04.3)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.26.1-1ubuntu1~16.04.8+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needs triage"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "curl": [
+        {
+            "name": "CVE-2021-22925",
+            "description": "curl supports the `-t` command line option, known as `CURLOPT_TELNETOPTIONS`in libcurl. This rarely used option is used to send variable=content pairs toTELNET servers.Due to flaw in the option parser for sending `NEW_ENV` variables, libcurlcould be made to pass on uninitialized data from a stack based buffer to theserver. Therefore potentially revealing sensitive internal information to theserver using a clear-text network protocol.This could happen because curl did not call and use sscanf() correctly whenparsing the string provided by the application.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-22925",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "7.47.0-1ubuntu2.19"
+                },
+                {
+                    "key": "package_name",
+                    "value": "curl"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:N"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "curl",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (7.78.0)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (7.74.0-1.2ubuntu4)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (7.68.0-1ubuntu2.6)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (7.58.0-2ubuntu3.14)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (7.47.0-1ubuntu2.19+esm3)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "caused by incomplete fix for CVE-2021-22898"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-22946",
+            "description": "A user can tell curl >= 7.20.0 and <= 7.78.0 to require a successful upgrade to TLS when speaking to an IMAP, POP3 or FTP server (`--ssl-reqd` on the command line or`CURLOPT_USE_SSL` set to `CURLUSESSL_CONTROL` or `CURLUSESSL_ALL` withlibcurl). This requirement could be bypassed if the server would return a properly crafted but perfectly legitimate response.This flaw would then make curl silently continue its operations **withoutTLS** contrary to the instructions and expectations, exposing possibly sensitive data in clear text over the network.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-22946",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "7.47.0-1ubuntu2.19"
+                },
+                {
+                    "key": "package_name",
+                    "value": "curl"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:N"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "curl",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (7.74.0-1.3ubuntu2)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (7.68.0-1ubuntu2.7)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (7.58.0-2ubuntu3.15)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (7.47.0-1ubuntu2.19+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (7.35.0-1ubuntu2.20+esm8)"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "introduced by:\nhttps://github.com/curl/curl/commit/ec3bb8f727405 and\nhttps://github.com/curl/curl/commit/c5ba0c2f544653"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-22947",
+            "description": "When curl >= 7.20.0 and <= 7.78.0 connects to an IMAP or POP3 server to retrieve data using STARTTLS to upgrade to TLS security, the server can respond and send back multiple responses at once that curl caches. curl would then upgrade to TLS but not flush the in-queue of cached responses but instead continue using and trustingthe responses it got *before* the TLS handshake as if they were authenticated.Using this flaw, it allows a Man-In-The-Middle attacker to first inject the fake responses, then pass-through the TLS traffic from the legitimate server and trick curl into sending data back to the user thinking the attacker's injected data comes from the TLS-protected server.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-22947",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "7.47.0-1ubuntu2.19"
+                },
+                {
+                    "key": "package_name",
+                    "value": "curl"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:N/I:P/A:N"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "4.3"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "curl",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (7.74.0-1.3ubuntu2)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (7.68.0-1ubuntu2.7)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (7.58.0-2ubuntu3.15)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (7.47.0-1ubuntu2.19+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (7.35.0-1ubuntu2.20+esm8)"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "Originally introduced via https://github.com/curl/curl/commit/ec3bb8f727405 - affects versions between and including 7.20.0 and 7.78.0 - patch in Message-ID: <nycvar.QRO.7.76.2109100828320.2614@fvyyl>"
+                    ]
+                }
+            ]
+        }
+    ],
+    "expat": [
+        {
+            "name": "CVE-2022-23852",
+            "description": "Expat (aka libexpat) before 2.4.4 has a signed integer overflow in XML_GetBuffer, for configurations with a nonzero XML_CONTEXT_BYTES.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-23852",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.1.0-7ubuntu0.16.04.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "expat"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "expat",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "CVE-2022-23990",
+            "description": "Expat (aka libexpat) before 2.4.4 has an integer overflow in the doProlog function.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-23990",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.1.0-7ubuntu0.16.04.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "expat"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "expat",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
+                    ]
+                }
+            ]
+        }
+    ],
+    "gcc-5": [
+        {
+            "name": "CVE-2020-13844",
+            "description": "Arm Armv8-A core implementations utilizing speculative execution past unconditional changes in control flow may allow unauthorized disclosure of information to an attacker with local user access via a side-channel analysis, aka \"straight-line speculation.\"",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-13844",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "5.4.0-6ubuntu1~16.04.12"
+                },
+                {
+                    "key": "package_name",
+                    "value": "gcc-5"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:L/AC:L/Au:N/C:P/I:N/A:N"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "2.1"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "gcc-5",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Does not exist"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "gcc-3.3 only provides libstdc++5"
+                    ]
+                }
+            ]
+        }
+    ],
+    "gcc-defaults": [
+        {
+            "name": "CVE-2020-13844",
+            "description": "Arm Armv8-A core implementations utilizing speculative execution past unconditional changes in control flow may allow unauthorized disclosure of information to an attacker with local user access via a side-channel analysis, aka \"straight-line speculation.\"",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-13844",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "1.150ubuntu1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "gcc-defaults"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:L/AC:L/Au:N/C:P/I:N/A:N"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "2.1"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "gcc-defaults",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Deferred"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "gcc-3.3 only provides libstdc++5"
+                    ]
+                }
+            ]
+        }
+    ],
+    "gccgo-6": [
+        {
+            "name": "CVE-2020-13844",
+            "description": "Arm Armv8-A core implementations utilizing speculative execution past unconditional changes in control flow may allow unauthorized disclosure of information to an attacker with local user access via a side-channel analysis, aka \"straight-line speculation.\"",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-13844",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "6.0.1-0ubuntu1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "gccgo-6"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:L/AC:L/Au:N/C:P/I:N/A:N"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "2.1"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "gccgo-6",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Does not exist"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "gcc-3.3 only provides libstdc++5"
+                    ]
+                }
+            ]
+        }
+    ],
+    "git": [
+        {
+            "name": "CVE-2021-40330",
+            "description": "git_connect_git in connect.c in Git before 2.30.1 allows a repository path to contain a newline character, which may result in unexpected cross-protocol requests, as demonstrated by the git://localhost:1234/%0d%0a%0d%0aGET%20/%20HTTP/1.1 substring.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-40330",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "1:2.7.4-0ubuntu1.10"
+                },
+                {
+                    "key": "package_name",
+                    "value": "git"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:N"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "git",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (1:2.30.1-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Not vulnerable"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (1:2.25.1-1ubuntu3.2)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (1:2.17.1-1ubuntu0.9)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (1:2.7.4-0ubuntu1.10+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "glib2.0": [
+        {
+            "name": "CVE-2021-3800",
+            "description": "glib2: Possible privilege escalation thourgh pkexec and aliases",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3800",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.48.2-0ubuntu4.8"
+                },
+                {
+                    "key": "package_name",
+                    "value": "glib2.0"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "glib2.0",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.62.5)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Not vulnerable (2.68.4-1ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Not vulnerable (2.64.6-1~ubuntu20.04.4)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.56.4-0ubuntu0.18.04.9)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.48.2-0ubuntu4.8+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (2.40.2-0ubuntu1.1+esm4)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "glibc": [
+        {
+            "name": "CVE-2021-38604",
+            "description": "In librt in the GNU C Library (aka glibc) through 2.34, sysdeps/unix/sysv/linux/mq_notify.c mishandles certain NOTIFY_REMOVED data, leading to a NULL pointer dereference. NOTE: this vulnerability was introduced as a side effect of the CVE-2021-33574 fix.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-38604",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.23-0ubuntu11.2"
+                },
+                {
+                    "key": "package_name",
+                    "value": "glibc"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "glibc",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Pending (2.35)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Not vulnerable (2.34-0ubuntu3)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream: Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "21.04 and earlier are not affected due to the fix for\nCVE-2021-33574 having not been introduced yet."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-38604",
+            "description": "In librt in the GNU C Library (aka glibc) through 2.34, sysdeps/unix/sysv/linux/mq_notify.c mishandles certain NOTIFY_REMOVED data, leading to a NULL pointer dereference. NOTE: this vulnerability was introduced as a side effect of the CVE-2021-33574 fix.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-38604",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.23-0ubuntu11.3"
+                },
+                {
+                    "key": "package_name",
+                    "value": "glibc"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "glibc",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Pending (2.35)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Not vulnerable (2.34-0ubuntu3)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream: Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "21.04 and earlier are not affected due to the fix for\nCVE-2021-33574 having not been introduced yet."
+                    ]
+                }
+            ]
+        }
+    ],
+    "imagemagick": [
+        {
+            "name": "CVE-2020-25664",
+            "description": "In WriteOnePNGImage() of the PNG coder at coders/png.c, an improper call to AcquireVirtualMemory() and memset() allows for an out-of-bounds write later when PopShortPixel() from MagickCore/quantum-private.h is called. The patch fixes the calls by adding 256 to rowbytes. An attacker who is able to supply a specially crafted image could affect availability with a low impact to data integrity. This flaw affects ImageMagick versions prior to 6.9.10-68 and 7.0.8-68.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-25664",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "8:6.8.9.9-7ubuntu5.16"
+                },
+                {
+                    "key": "package_name",
+                    "value": "imagemagick"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:N/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "imagemagick",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (8:6.9.11.24+dfsg-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream: Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "fix attempt was reverted\nunclear what the fix for this issue is as of 2021-06-10"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "CVE-2020-27752",
+            "description": "A flaw was found in ImageMagick in MagickCore/quantum-private.h. An attacker who submits a crafted file that is processed by ImageMagick could trigger a heap buffer overflow. This would most likely lead to an impact to application availability, but could potentially lead to an impact to data integrity as well. This flaw affects ImageMagick versions prior to 7.0.9-0.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-27752",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "8:6.8.9.9-7ubuntu5.16"
+                },
+                {
+                    "key": "package_name",
+                    "value": "imagemagick"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:N/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "imagemagick",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (8:6.9.11.24+dfsg-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Not vulnerable (8:6.9.11.60+dfsg-1ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Does not exist"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "need to clarify exact patch, see Debian comment on upstream bug"
+                    ]
+                }
+            ]
+        }
+    ],
+    "krb5": [
+        {
+            "name": "CVE-2018-20217",
+            "description": "A Reachable Assertion issue was discovered in the KDC in MIT Kerberos 5 (aka krb5) before 1.17. If an attacker can obtain a krbtgt ticket using an older encryption type (single-DES, triple-DES, or RC4), the attacker can crash the KDC by making an S4U2Self request.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20217",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "1.13.2+dfsg-5ubuntu2.2"
+                },
+                {
+                    "key": "package_name",
+                    "value": "krb5"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:S/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "3.5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "krb5",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (1.17)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Not vulnerable (1.17-10)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Not vulnerable (1.17-6ubuntu4)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ],
+                            [
+                                "Binaries built from this source package are in",
+                                "and so are supported by the community."
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "libgcrypt20": [
+        {
+            "name": "CVE-2021-40528",
+            "description": "The ElGamal implementation in Libgcrypt before 1.9.4 allows plaintext recovery because, during interaction between two cryptographic libraries, a certain dangerous combination of the prime defined by the receiver's public key, the generator defined by the receiver's public key, and the sender's ephemeral exponents can lead to a cross-configuration attack against OpenPGP.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-40528",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "1.6.5-2ubuntu0.6"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libgcrypt20"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:H/Au:N/C:P/I:N/A:N"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "2.6"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libgcrypt20",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (1.9.4-2)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (1.8.7-5ubuntu2)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (1.8.5-5ubuntu1.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (1.8.1-4ubuntu1.3)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (1.6.5-2ubuntu0.6+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream: Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "The commits below reference CVE-2021-33560, but they appear to\nactually be for this CVE, which was issued later. The original\nCVE was switched later on to the exponent blinding issue\ninstead."
+                    ]
+                }
+            ]
+        }
+    ],
+    "libgd2": [
+        {
+            "name": "CVE-2021-40145",
+            "description": "** DISPUTED ** gdImageGd2Ptr in gd_gd2.c in the GD Graphics Library (aka LibGD) through 2.3.2 has a double free. NOTE: the vendor's position is \"The GD2 image format is a proprietary image format of libgd. It has to be regarded as being obsolete, and should only be used for development and testing purposes.\"",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-40145",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.1.1-4ubuntu0.16.04.12"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libgd2"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libgd2",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2.3.0-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.2.5-5.2ubuntu2.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.2.5-4ubuntu0.5)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.1.1-4ubuntu0.16.04.12+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (2.1.0-3ubuntu0.11+esm2)"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "php uses the system libgd2"
+                    ]
+                }
+            ]
+        }
+    ],
+    "libwebp": [
+        {
+            "name": "CVE-2018-25009",
+            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function WebPMuxCreateInternal. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25009",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.4.4-1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libwebp"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.4"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2018-25010",
+            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function ApplyFilter. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25010",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.4.4-1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libwebp"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.4"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2018-25011",
+            "description": "A flaw was found in libwebp in versions before 1.0.1. A heap-based buffer overflow was found in PutLE16(). The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25011",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.4.4-1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libwebp"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream: Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2018-25012",
+            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function WebPMuxCreateInternal. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25012",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.4.4-1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libwebp"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.4"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "same commit as CVE-2018-25009"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "CVE-2018-25013",
+            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function ShiftBytes. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25013",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.4.4-1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libwebp"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.4"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2018-25014",
+            "description": "A flaw was found in libwebp in versions before 1.0.1. An unitialized variable is used in function ReadSymbol. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25014",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.4.4-1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libwebp"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2020-36328",
+            "description": "A flaw was found in libwebp in versions before 1.0.1. A heap-based buffer overflow in function WebPDecodeRGBInto is possible due to an invalid check for buffer size. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36328",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.4.4-1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libwebp"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2020-36329",
+            "description": "A flaw was found in libwebp in versions before 1.0.1. A use-after-free was found due to a thread being killed too early. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36329",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.4.4-1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libwebp"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2020-36330",
+            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function ChunkVerifyAndAssign. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36330",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.4.4-1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libwebp"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.4"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2020-36331",
+            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function ChunkAssignData. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36331",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.4.4-1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libwebp"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.4"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "libx11": [
+        {
+            "name": "CVE-2021-31535",
+            "description": "LookupCol.c in X.Org X through X11R7.7 and libX11 before 1.7.1 might allow remote attackers to execute arbitrary code. The libX11 XLookupColor request (intended for server-side color lookup) contains a flaw allowing a client to send color-name requests with a name longer than the maximum size allowed by the protocol (and also longer than the maximum packet size for normal-sized packets). The user-controlled data exceeding the maximum size is then interpreted by the server as additional X protocol requests and executed, e.g., to disable X server authorization completely. For example, if the victim encounters malicious terminal control sequences for color codes, then the attacker may be able to take full control of the running graphical session.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-31535",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2:1.6.3-1ubuntu2.2"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libx11"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libx11",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (1.7.0-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2:1.6.9-2ubuntu1.2)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2:1.6.4-3ubuntu0.4)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2:1.6.3-1ubuntu2.2+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (2:1.6.2-1ubuntu2.1+esm2)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "libxml2": [
+        {
+            "name": "CVE-2021-3516",
+            "description": "There's a flaw in libxml2's xmllint in versions before 2.9.11. An attacker who is able to submit a crafted file to be processed by xmllint could trigger a use-after-free. The greatest impact of this flaw is to confidentiality, integrity, and availability.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3516",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.9.3+dfsg1-1ubuntu0.7"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libxml2"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libxml2",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.9.10+dfsg-6.6)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Not vulnerable (2.9.10+dfsg-6.7)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.9.4+dfsg1-6.1ubuntu1.4)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (2.9.1+dfsg1-3ubuntu4.13+esm2)"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-3517",
+            "description": "There is a flaw in the xml entity encoding functionality of libxml2 in versions before 2.9.11. An attacker who is able to supply a crafted file to be processed by an application linked with the affected functionality of libxml2 could trigger an out-of-bounds read. The most likely impact of this flaw is to application availability, with some potential impact to confidentiality and integrity if an attacker is able to use memory information to further exploit the application.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3517",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.9.3+dfsg1-1ubuntu0.7"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libxml2"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libxml2",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.9.10+dfsg-6.6)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Not vulnerable (2.9.10+dfsg-6.7)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.9.4+dfsg1-6.1ubuntu1.4)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (2.9.1+dfsg1-3ubuntu4.13+esm2)"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-3518",
+            "description": "There's a flaw in libxml2 in versions before 2.9.11. An attacker who is able to submit a crafted file to be processed by an application linked with libxml2 could trigger a use-after-free. The greatest impact from this flaw is to confidentiality, integrity, and availability.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3518",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.9.3+dfsg1-1ubuntu0.7"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libxml2"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libxml2",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.9.10+dfsg-6.6)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Not vulnerable (2.9.10+dfsg-6.7)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.9.4+dfsg1-6.1ubuntu1.4)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (2.9.1+dfsg1-3ubuntu4.13+esm2)"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-3537",
+            "description": "A vulnerability found in libxml2 in versions before 2.9.11 shows that it did not propagate errors while parsing XML mixed content, causing a NULL dereference. If an untrusted XML document was parsed in recovery mode and post-validated, the flaw could be used to crash the application. The highest threat from this vulnerability is to system availability.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3537",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.9.3+dfsg1-1ubuntu0.7"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libxml2"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "4.3"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "libxml2",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.9.10+dfsg-6.6)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Not vulnerable (2.9.10+dfsg-6.7)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.9.4+dfsg1-6.1ubuntu1.4)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (2.9.1+dfsg1-3ubuntu4.13+esm2)"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "lz4": [
+        {
+            "name": "CVE-2021-3520",
+            "description": "There's a flaw in lz4. An attacker who submits a crafted file to an application linked with lz4 may be able to trigger an integer overflow, leading to calling of memmove() on a negative size argument, causing an out-of-bounds write and/or a crash. The greatest impact of this flaw is to availability, with some potential impact to confidentiality and integrity as well.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3520",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.0~r131-2ubuntu2"
+                },
+                {
+                    "key": "package_name",
+                    "value": "lz4"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "lz4",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (1.9.3-2)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Not vulnerable (1.9.3-2)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (1.9.2-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (0.0~r131-2ubuntu3.1)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (0.0~r131-2ubuntu2+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (0.0~r114-2ubuntu1+esm2)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "nettle": [
+        {
+            "name": "CVE-2021-20305",
+            "description": "A flaw was found in Nettle in versions before 3.7.2, where several Nettle signature verification functions (GOST DSA, EDDSA & ECDSA) result in the Elliptic Curve Cryptography point (ECC) multiply function being called with out-of-range scalers, possibly resulting in incorrect results. This flaw allows an attacker to force an invalid signature, causing an assertion failure or possible validation. The highest threat to this vulnerability is to confidentiality, integrity, as well as system availability.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-20305",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "3.2-1ubuntu0.16.04.1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "nettle"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "nettle",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (3.7.2-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (3.7-2.1ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (3.5.1+really3.5.1-2ubuntu0.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (3.4-1ubuntu0.1)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (3.2-1ubuntu0.16.04.2)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needs triage"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream: Upstream: Upstream: Upstream: Upstream: Upstream: Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "openexr": [
+        {
+            "name": "CVE-2021-3605",
+            "description": "There's a flaw in OpenEXR's rleUncompress functionality in versions prior to 3.0.5. An attacker who is able to submit a crafted file to an application linked with OpenEXR could cause an out-of-bounds read. The greatest risk from this flaw is to application availability.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3605",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.2.0-10ubuntu2.6"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openexr"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "4.3"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openexr",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.5.7-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.2.0-11.1ubuntu1.7)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.2.0-10ubuntu2.6+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-3933",
+            "description": "openexr: Integer-overflow in Imf_3_1::bytesPerDeepLineTable",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3933",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.2.0-10ubuntu2.6"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openexr"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openexr",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.2.0-11.1ubuntu1.8)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.2.0-10ubuntu2.6+esm2)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Ignored (out of standard support)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "openldap": [
+        {
+            "name": "CVE-2020-36221",
+            "description": "An integer underflow was discovered in OpenLDAP before 2.4.57 leading to slapd crashes in the Certificate Exact Assertion processing, resulting in denial of service (schema_init.c serialNumberAndIssuerCheck).",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36221",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.4.42+dfsg-2ubuntu3.11"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openldap"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream: Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2020-36222",
+            "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to an assertion failure in slapd in the saslAuthzTo validation, resulting in denial of service.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36222",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.4.42+dfsg-2ubuntu3.11"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openldap"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream: Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2020-36223",
+            "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to a slapd crash in the Values Return Filter control handling, resulting in denial of service (double free and out-of-bounds read).",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36223",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.4.42+dfsg-2ubuntu3.11"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openldap"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2020-36224",
+            "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to an invalid pointer free and slapd crash in the saslAuthzTo processing, resulting in denial of service.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36224",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.4.42+dfsg-2ubuntu3.11"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openldap"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream: Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2020-36225",
+            "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to a double free and slapd crash in the saslAuthzTo processing, resulting in denial of service.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36225",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.4.42+dfsg-2ubuntu3.11"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openldap"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2020-36226",
+            "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to a memch->bv_len miscalculation and slapd crash in the saslAuthzTo processing, resulting in denial of service.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36226",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.4.42+dfsg-2ubuntu3.11"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openldap"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2020-36227",
+            "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to an infinite loop in slapd with the cancel_extop Cancel operation, resulting in denial of service.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36227",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.4.42+dfsg-2ubuntu3.11"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openldap"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2020-36228",
+            "description": "An integer underflow was discovered in OpenLDAP before 2.4.57 leading to a slapd crash in the Certificate List Exact Assertion processing, resulting in denial of service.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36228",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.4.42+dfsg-2ubuntu3.11"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openldap"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2020-36229",
+            "description": "A flaw was discovered in ldap_X509dn2bv in OpenLDAP before 2.4.57 leading to a slapd crash in the X.509 DN parsing in ad_keystring, resulting in denial of service.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36229",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.4.42+dfsg-2ubuntu3.11"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openldap"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2020-36230",
+            "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading in an assertion failure in slapd in the X.509 DN parsing in decode.c ber_next_element, resulting in denial of service.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36230",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.4.42+dfsg-2ubuntu3.11"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openldap"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-27212",
+            "description": "In OpenLDAP through 2.4.57 and 2.5.x through 2.5.1alpha, an assertion failure in slapd can occur in the issuerAndThisUpdateCheck function via a crafted packet, resulting in a denial of service (daemon exit) via a short timestamp. This is related to schema_init.c and checkTime.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-27212",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.4.42+dfsg-2ubuntu3.11"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openldap"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (2.4.57+dfsg-2)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2.4.49+dfsg-2ubuntu1.7)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2.4.45+dfsg-1ubuntu1.10)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2.4.42+dfsg-2ubuntu3.13)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream: Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "openssl": [
+        {
+            "name": "CVE-2021-23841",
+            "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-23841",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "1.0.2g-1ubuntu4.18"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openssl"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "4.3"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openssl",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (1.1.1j)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (1.1.1f-1ubuntu2.2)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (1.1.1-1ubuntu2.1~18.04.8)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (1.0.2g-1ubuntu4.19)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (1.0.1f-1ubuntu2.27+esm2)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "edk2 doesn't use the affected function"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-3712",
+            "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3712",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "1.0.2g-1ubuntu4.18"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openssl"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openssl",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (1.1.1l-1ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (1.1.1f-1ubuntu2.8)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (1.1.1-1ubuntu2.1~18.04.13)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (1.0.2g-1ubuntu4.20+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (1.0.1f-1ubuntu2.27+esm4)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "in 1.0.2, this bug is in X509_CERT_AUX_print()\nlist of commits below is incomplete"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-3712",
+            "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3712",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "1.0.2g-1ubuntu4.20"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openssl"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "openssl",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (1.1.1l-1ubuntu1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (1.1.1f-1ubuntu2.8)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (1.1.1-1ubuntu2.1~18.04.13)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (1.0.2g-1ubuntu4.20+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (1.0.1f-1ubuntu2.27+esm4)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "in 1.0.2, this bug is in X509_CERT_AUX_print()\nlist of commits below is incomplete"
+                    ]
+                }
+            ]
+        }
+    ],
+    "p11-kit": [
+        {
+            "name": "CVE-2020-29361",
+            "description": "An issue was discovered in p11-kit 0.21.1 through 0.23.21. Multiple integer overflows have been discovered in the array allocations in the p11-kit library and the p11-kit list command, where overflow checks are missing before calling realloc or calloc.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-29361",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.23.2-5~ubuntu16.04.1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "p11-kit"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "p11-kit",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (0.23.22-1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (0.23.20-1ubuntu0.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (0.23.9-2ubuntu0.1)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (0.23.2-5~ubuntu16.04.2)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (0.20.2-2ubuntu2+esm1)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream: Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2020-29362",
+            "description": "An issue was discovered in p11-kit 0.21.1 through 0.23.21. A heap-based buffer over-read has been discovered in the RPC protocol used by thep11-kit server/remote commands and the client library. When the remote entity supplies a byte array through a serialized PKCS#11 function call, the receiving entity may allow the reading of up to 4 bytes of memory past the heap allocation.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-29362",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.23.2-5~ubuntu16.04.1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "p11-kit"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:N"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "p11-kit",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (0.23.22-1)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (0.23.22-1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (0.23.20-1ubuntu0.1)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (0.23.9-2ubuntu0.1)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (0.23.2-5~ubuntu16.04.2)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Not vulnerable (code not present)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "perl": [
+        {
+            "name": "CVE-2020-16156",
+            "description": "CPAN 2.28 allows Signature Verification Bypass.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-16156",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "5.22.1-9ubuntu0.9"
+                },
+                {
+                    "key": "package_name",
+                    "value": "perl"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "perl",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "Fix is in cpanpm 2.29"
+                    ]
+                }
+            ]
+        }
+    ],
+    "python3.5": [
+        {
+            "name": "CVE-2021-3733",
+            "description": "[Denial of service when identifying crafted invalid RFCs]",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3733",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "3.5.2-2ubuntu0~16.04.13"
+                },
+                {
+                    "key": "package_name",
+                    "value": "python3.5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "python3.5",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (3.5.2-2ubuntu0~16.04.13+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "code affected in hirsute and devel is already patched, so both releases\nin python3.9 are not affected."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-3737",
+            "description": "[client can enter an infinite loop on a 100 Continue response from the server]",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3737",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "3.5.2-2ubuntu0~16.04.13"
+                },
+                {
+                    "key": "package_name",
+                    "value": "python3.5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "python3.5",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (3.5.2-2ubuntu0~16.04.13+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "impish/devel is not affected, code supposed affected was patched already."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-4189",
+            "description": "[ftplib should not use the host from the PASV response]",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-4189",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "3.5.2-2ubuntu0~16.04.13"
+                },
+                {
+                    "key": "package_name",
+                    "value": "python3.5"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "python3.5",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Does not exist"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "sqlite3": [
+        {
+            "name": "CVE-2020-9794",
+            "description": "An out-of-bounds read was addressed with improved bounds checking. This issue is fixed in iOS 13.5 and iPadOS 13.5, macOS Catalina 10.15.5, tvOS 13.4.5, watchOS 6.2.5, iTunes 12.10.7 for Windows, iCloud for Windows 11.2, iCloud for Windows 7.19. A malicious application may cause a denial of service or potentially disclose memory contents.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-9794",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "3.11.0-1ubuntu1.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "sqlite3"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "sqlite3",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Deferred"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "This may be an Apple-specific CVE, as of 2021-02-08, no details\nare available as to what the upstream fix is."
+                    ]
+                }
+            ]
+        }
+    ],
+    "systemd": [
+        {
+            "name": "CVE-2021-33910",
+            "description": "basic/unit-name.c in systemd prior to 246.15, 247.8, 248.5, and 249.1 has a Memory Allocation with an Excessive Size Value (involving strdupa and alloca for a pathname controlled by a local attacker) that results in an operating system crash.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-33910",
+            "severity": "HIGH",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "229-4ubuntu21.29"
+                },
+                {
+                    "key": "package_name",
+                    "value": "systemd"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:L/AC:L/Au:N/C:N/I:N/A:C"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "4.9"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "systemd",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (248.3-1ubuntu3)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (245.4-4ubuntu3.10)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (237-3ubuntu10.49)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (229-4ubuntu21.31+esm1)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Not vulnerable"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "vim": [
+        {
+            "name": "CVE-2021-3778",
+            "description": "vim is vulnerable to Heap-based Buffer Overflow",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3778",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2:7.4.1689-3ubuntu1.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "vim"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "vim",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (v8.2.3409)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2:8.2.2434-3ubuntu2)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2:8.1.2269-1ubuntu5.3)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2:8.0.1453-1ubuntu1.6)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2:7.4.1689-3ubuntu1.5+esm2)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (2:7.4.052-1ubuntu3.1+esm3)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-3796",
+            "description": "vim is vulnerable to Use After Free",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3796",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2:7.4.1689-3ubuntu1.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "vim"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "vim",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (v8.2.3428)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2:8.2.2434-3ubuntu2)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2:8.1.2269-1ubuntu5.3)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2:8.0.1453-1ubuntu1.6)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2:7.4.1689-3ubuntu1.5+esm2)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (2:7.4.052-1ubuntu3.1+esm3)"
+                            ],
+                            [
+                                "Patches:",
+                                "Upstream:"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-3927",
+            "description": "vim is vulnerable to Heap-based Buffer Overflow",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3927",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2:7.4.1689-3ubuntu1.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "vim"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "vim",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (v8.2.3581)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2:8.2.2434-3ubuntu3.1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2:8.1.2269-1ubuntu5.4)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2:8.0.1453-1ubuntu1.7)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2:7.4.1689-3ubuntu1.5+esm3)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (2:7.4.052-1ubuntu3.1+esm4)"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-3928",
+            "description": "vim is vulnerable to Use of Uninitialized Variable",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3928",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2:7.4.1689-3ubuntu1.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "vim"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:L/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "4.6"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "vim",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (v8.2.3582)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2:8.2.2434-3ubuntu3.1)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2:8.1.2269-1ubuntu5.4)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2:8.0.1453-1ubuntu1.7)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Released (2:7.4.1689-3ubuntu1.5+esm3)"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Released (2:7.4.052-1ubuntu3.1+esm4)"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-3984",
+            "description": "vim is vulnerable to Heap-based Buffer Overflow",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3984",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2:7.4.1689-3ubuntu1.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "vim"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "vim",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (v8.2.3625)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2:8.2.2434-3ubuntu3.2)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2:8.1.2269-1ubuntu5.6)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2:8.0.1453-1ubuntu1.8)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "for bionic and earlier, the vulnerable function in src/cindent.c\nis in src/misc1.c."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-4019",
+            "description": "vim is vulnerable to Heap-based Buffer Overflow",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-4019",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2:7.4.1689-3ubuntu1.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "vim"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "vim",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (v8.2.3669)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2:8.2.2434-3ubuntu3.2)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2:8.1.2269-1ubuntu5.6)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2:8.0.1453-1ubuntu1.8)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "in focal and earlier vulnerable function from src/help.c\nis in src/ex_cmds.c."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "CVE-2021-4069",
+            "description": "vim is vulnerable to Use After Free",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-4069",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2:7.4.1689-3ubuntu1.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "vim"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "vim",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Released (v8.2.3761)"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Released (2:8.2.2434-3ubuntu3.2)"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Released (2:8.1.2269-1ubuntu5.6)"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Released (2:8.0.1453-1ubuntu1.8)"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2022-0351",
+            "description": "Access of Memory Location Before Start of Buffer in Conda vim prior to 8.2.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-0351",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2:7.4.1689-3ubuntu1.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "vim"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:L/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "4.6"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "vim",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2022-0359",
+            "description": "Heap-based Buffer Overflow in Conda vim prior to 8.2.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-0359",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2:7.4.1689-3ubuntu1.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "vim"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "vim",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        },
+        {
+            "name": "CVE-2022-0361",
+            "description": "Heap-based Buffer Overflow in Conda vim prior to 8.2.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-0361",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2:7.4.1689-3ubuntu1.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "vim"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "vim",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Needed"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Needed"
+                            ]
+                        ]
+                    },
+                    "notes": []
+                }
+            ]
+        }
+    ],
+    "wget": [
+        {
+            "name": "CVE-2021-31879",
+            "description": "GNU Wget through 1.21.1 does not omit the Authorization header upon a redirect to a different origin, a related issue to CVE-2018-1000007.",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-31879",
+            "severity": "MEDIUM",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "1.17.1-1ubuntu1.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "wget"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:N"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5.8"
+                }
+            ],
+            "scraped_data": [
+                {
+                    "status_table": {
+                        "packages": [
+                            "wget",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "Upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "Ubuntu 21.10 (Impish Indri)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "Deferred"
+                            ],
+                            [
+                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "Deferred"
+                            ]
+                        ]
+                    },
+                    "notes": [
+                        "no upstream fix as of 2022-01-05\nalso see previous upstream bug from 2019"
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Total vulnerabilites that can be fixed 0
Total vulnerabilites that can NOT be fixed 31


Fixable vulnerabilites:

```
[]
```

Non-Fixable vulnerabilites:

```
{
    "systemd": [
        {
            "name": "CVE-2021-33910",
            "description": "basic/unit-name.c in systemd prior to 246.15, 247.8, 248.5, and 249.1 has a Memory Allocation with an Excessive Size Value (involving strdupa and alloca for a pathname controlled by a local attacker) that results in an operating system crash.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-33910",
            "severity": "HIGH",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "229-4ubuntu21.29"
                },
                {
                    "key": "package_name",
                    "value": "systemd"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:L/AC:L/Au:N/C:N/I:N/A:C"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "4.9"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "systemd",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (248.3-1ubuntu3)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (245.4-4ubuntu3.10)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (237-3ubuntu10.49)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (229-4ubuntu21.31+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Not vulnerable"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "apparmor": [
        {
            "name": "CVE-2016-1585",
            "description": "In all versions of AppArmor mount rules are accidentally widened when compiled.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-1585",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.10.95-0ubuntu2.11"
                },
                {
                    "key": "package_name",
                    "value": "apparmor"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "7.5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "apparmor",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Deferred"
                            ]
                        ]
                    },
                    "notes": [
                        "no fix as of 2020-10-19"
                    ]
                }
            ]
        }
    ],
    "apt": [
        {
            "name": "CVE-2020-27350",
            "description": "APT had several integer overflows and underflows while parsing .deb packages, aka GHSL-2020-168 GHSL-2020-169, in files apt-pkg/contrib/extracttar.cc, apt-pkg/deb/debfile.cc, and apt-pkg/contrib/arfile.cc. This issue affects: apt 1.2.32ubuntu0 versions prior to 1.2.32ubuntu0.2; 1.6.12ubuntu0 versions prior to 1.6.12ubuntu0.2; 2.0.2ubuntu0 versions prior to 2.0.2ubuntu0.2; 2.1.10ubuntu0 versions prior to 2.1.10ubuntu0.1;",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-27350",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "1.2.32ubuntu0.1"
                },
                {
                    "key": "package_name",
                    "value": "apt"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:L/AC:L/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "4.6"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "apt",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.0.2ubuntu0.2)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (1.6.12ubuntu0.2)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (1.2.32ubuntu0.2)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (1.0.1ubuntu2.24+esm3)"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "avahi": [
        {
            "name": "CVE-2021-3468",
            "description": "A flaw was found in avahi in versions 0.6 up to 0.8. The event used to signal the termination of the client connection on the avahi Unix socket is not correctly handled in the client_work function, allowing a local attacker to trigger an infinite loop. The highest threat from this vulnerability is to the availability of the avahi service, which becomes unresponsive after this flaw is triggered.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3468",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "0.6.32~rc+dfsg-1ubuntu2.3"
                },
                {
                    "key": "package_name",
                    "value": "avahi"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:L/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "2.1"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "avahi",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needed"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (0.8-5ubuntu3)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (0.7-4ubuntu7.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (0.7-3.1ubuntu1.3)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (0.6.32~rc+dfsg-1ubuntu2.3+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (0.6.31-4ubuntu1.3+esm1)"
                            ],
                            [
                                "Patches:",
                                "Other:"
                            ]
                        ]
                    },
                    "notes": [
                        "as of 2021-07-06, the proposed patch has not been commited\nupstream"
                    ]
                }
            ]
        }
    ],
    "binutils": [
        {
            "name": "CVE-2019-17451",
            "description": "An issue was discovered in the Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils 2.32. It is an integer overflow leading to a SEGV in _bfd_dwarf2_find_nearest_line in dwarf2.c, as demonstrated by nm.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17451",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.26.1-1ubuntu1~16.04.8"
                },
                {
                    "key": "package_name",
                    "value": "binutils"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "4.3"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "binutils",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Not vulnerable (2.34-5ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Not vulnerable (2.34-5ubuntu1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.30-21ubuntu1~18.04.3)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.26.1-1ubuntu1~16.04.8+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needs triage"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2019-14250",
            "description": "An issue was discovered in GNU libiberty, as distributed in GNU Binutils 2.32. simple_object_elf_match in simple-object-elf.c does not check for a zero shstrndx value, leading to an integer overflow and resultant heap-based buffer overflow.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-14250",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.26.1-1ubuntu1~16.04.8"
                },
                {
                    "key": "package_name",
                    "value": "binutils"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "4.3"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "binutils",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.33)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Not vulnerable (2.34-5ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Not vulnerable (2.34-5ubuntu1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.30-21ubuntu1~18.04.3)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.26.1-1ubuntu1~16.04.8+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needs triage"
                            ],
                            [
                                "Patches:",
                                "Other: Vendor:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2019-14444",
            "description": "apply_relocations in readelf.c in GNU Binutils 2.32 contains an integer overflow that allows attackers to trigger a write access violation (in byte_put_little_endian function in elfcomm.c) via an ELF file, as demonstrated by readelf.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-14444",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.26.1-1ubuntu1~16.04.8"
                },
                {
                    "key": "package_name",
                    "value": "binutils"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "4.3"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "binutils",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.32.51.20190813-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Not vulnerable (2.34-5ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Not vulnerable (2.34-5ubuntu1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.30-21ubuntu1~18.04.3)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.26.1-1ubuntu1~16.04.8+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "curl": [
        {
            "name": "CVE-2021-22925",
            "description": "curl supports the `-t` command line option, known as `CURLOPT_TELNETOPTIONS`in libcurl. This rarely used option is used to send variable=content pairs toTELNET servers.Due to flaw in the option parser for sending `NEW_ENV` variables, libcurlcould be made to pass on uninitialized data from a stack based buffer to theserver. Therefore potentially revealing sensitive internal information to theserver using a clear-text network protocol.This could happen because curl did not call and use sscanf() correctly whenparsing the string provided by the application.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-22925",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "7.47.0-1ubuntu2.19"
                },
                {
                    "key": "package_name",
                    "value": "curl"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:N"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "curl",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (7.78.0)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (7.74.0-1.2ubuntu4)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (7.68.0-1ubuntu2.6)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (7.58.0-2ubuntu3.14)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (7.47.0-1ubuntu2.19+esm3)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ]
                        ]
                    },
                    "notes": [
                        "caused by incomplete fix for CVE-2021-22898"
                    ]
                }
            ]
        },
        {
            "name": "CVE-2021-22947",
            "description": "When curl >= 7.20.0 and <= 7.78.0 connects to an IMAP or POP3 server to retrieve data using STARTTLS to upgrade to TLS security, the server can respond and send back multiple responses at once that curl caches. curl would then upgrade to TLS but not flush the in-queue of cached responses but instead continue using and trustingthe responses it got *before* the TLS handshake as if they were authenticated.Using this flaw, it allows a Man-In-The-Middle attacker to first inject the fake responses, then pass-through the TLS traffic from the legitimate server and trick curl into sending data back to the user thinking the attacker's injected data comes from the TLS-protected server.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-22947",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "7.47.0-1ubuntu2.19"
                },
                {
                    "key": "package_name",
                    "value": "curl"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:N/I:P/A:N"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "4.3"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "curl",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (7.74.0-1.3ubuntu2)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (7.68.0-1ubuntu2.7)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (7.58.0-2ubuntu3.15)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (7.47.0-1ubuntu2.19+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (7.35.0-1ubuntu2.20+esm8)"
                            ]
                        ]
                    },
                    "notes": [
                        "Originally introduced via https://github.com/curl/curl/commit/ec3bb8f727405 - affects versions between and including 7.20.0 and 7.78.0 - patch in Message-ID: <nycvar.QRO.7.76.2109100828320.2614@fvyyl>"
                    ]
                }
            ]
        },
        {
            "name": "CVE-2021-22946",
            "description": "A user can tell curl >= 7.20.0 and <= 7.78.0 to require a successful upgrade to TLS when speaking to an IMAP, POP3 or FTP server (`--ssl-reqd` on the command line or`CURLOPT_USE_SSL` set to `CURLUSESSL_CONTROL` or `CURLUSESSL_ALL` withlibcurl). This requirement could be bypassed if the server would return a properly crafted but perfectly legitimate response.This flaw would then make curl silently continue its operations **withoutTLS** contrary to the instructions and expectations, exposing possibly sensitive data in clear text over the network.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-22946",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "7.47.0-1ubuntu2.19"
                },
                {
                    "key": "package_name",
                    "value": "curl"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:N"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "curl",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (7.74.0-1.3ubuntu2)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (7.68.0-1ubuntu2.7)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (7.58.0-2ubuntu3.15)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (7.47.0-1ubuntu2.19+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (7.35.0-1ubuntu2.20+esm8)"
                            ]
                        ]
                    },
                    "notes": [
                        "introduced by:\nhttps://github.com/curl/curl/commit/ec3bb8f727405 and\nhttps://github.com/curl/curl/commit/c5ba0c2f544653"
                    ]
                }
            ]
        }
    ],
    "expat": [
        {
            "name": "CVE-2022-23852",
            "description": "Expat (aka libexpat) before 2.4.4 has a signed integer overflow in XML_GetBuffer, for configurations with a nonzero XML_CONTEXT_BYTES.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-23852",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.1.0-7ubuntu0.16.04.5"
                },
                {
                    "key": "package_name",
                    "value": "expat"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "7.5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "expat",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ]
                        ]
                    },
                    "notes": [
                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
                    ]
                }
            ]
        },
        {
            "name": "CVE-2022-23990",
            "description": "Expat (aka libexpat) before 2.4.4 has an integer overflow in the doProlog function.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-23990",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.1.0-7ubuntu0.16.04.5"
                },
                {
                    "key": "package_name",
                    "value": "expat"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "7.5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "expat",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ]
                        ]
                    },
                    "notes": [
                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
                    ]
                }
            ]
        }
    ],
    "gcc-5": [
        {
            "name": "CVE-2020-13844",
            "description": "Arm Armv8-A core implementations utilizing speculative execution past unconditional changes in control flow may allow unauthorized disclosure of information to an attacker with local user access via a side-channel analysis, aka \"straight-line speculation.\"",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-13844",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "5.4.0-6ubuntu1~16.04.12"
                },
                {
                    "key": "package_name",
                    "value": "gcc-5"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:L/AC:L/Au:N/C:P/I:N/A:N"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "2.1"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "gcc-5",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Does not exist"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Does not exist"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Does not exist"
                            ]
                        ]
                    },
                    "notes": [
                        "gcc-3.3 only provides libstdc++5"
                    ]
                }
            ]
        }
    ],
    "gcc-defaults": [
        {
            "name": "CVE-2020-13844",
            "description": "Arm Armv8-A core implementations utilizing speculative execution past unconditional changes in control flow may allow unauthorized disclosure of information to an attacker with local user access via a side-channel analysis, aka \"straight-line speculation.\"",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-13844",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "1.150ubuntu1"
                },
                {
                    "key": "package_name",
                    "value": "gcc-defaults"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:L/AC:L/Au:N/C:P/I:N/A:N"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "2.1"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "gcc-defaults",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Deferred"
                            ]
                        ]
                    },
                    "notes": [
                        "gcc-3.3 only provides libstdc++5"
                    ]
                }
            ]
        }
    ],
    "gccgo-6": [
        {
            "name": "CVE-2020-13844",
            "description": "Arm Armv8-A core implementations utilizing speculative execution past unconditional changes in control flow may allow unauthorized disclosure of information to an attacker with local user access via a side-channel analysis, aka \"straight-line speculation.\"",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-13844",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "6.0.1-0ubuntu1"
                },
                {
                    "key": "package_name",
                    "value": "gccgo-6"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:L/AC:L/Au:N/C:P/I:N/A:N"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "2.1"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "gccgo-6",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Does not exist"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Does not exist"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Does not exist"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Does not exist"
                            ]
                        ]
                    },
                    "notes": [
                        "gcc-3.3 only provides libstdc++5"
                    ]
                }
            ]
        }
    ],
    "git": [
        {
            "name": "CVE-2021-40330",
            "description": "git_connect_git in connect.c in Git before 2.30.1 allows a repository path to contain a newline character, which may result in unexpected cross-protocol requests, as demonstrated by the git://localhost:1234/%0d%0a%0d%0aGET%20/%20HTTP/1.1 substring.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-40330",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "1:2.7.4-0ubuntu1.10"
                },
                {
                    "key": "package_name",
                    "value": "git"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:N"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "git",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (1:2.30.1-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Not vulnerable"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (1:2.25.1-1ubuntu3.2)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (1:2.17.1-1ubuntu0.9)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (1:2.7.4-0ubuntu1.10+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Does not exist"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "glib2.0": [
        {
            "name": "CVE-2021-3800",
            "description": "glib2: Possible privilege escalation thourgh pkexec and aliases",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3800",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.48.2-0ubuntu4.8"
                },
                {
                    "key": "package_name",
                    "value": "glib2.0"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "glib2.0",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.62.5)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Not vulnerable (2.68.4-1ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Not vulnerable (2.64.6-1~ubuntu20.04.4)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.56.4-0ubuntu0.18.04.9)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.48.2-0ubuntu4.8+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (2.40.2-0ubuntu1.1+esm4)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "glibc": [
        {
            "name": "CVE-2021-38604",
            "description": "In librt in the GNU C Library (aka glibc) through 2.34, sysdeps/unix/sysv/linux/mq_notify.c mishandles certain NOTIFY_REMOVED data, leading to a NULL pointer dereference. NOTE: this vulnerability was introduced as a side effect of the CVE-2021-33574 fix.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-38604",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.23-0ubuntu11.2"
                },
                {
                    "key": "package_name",
                    "value": "glibc"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "glibc",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Pending (2.35)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Not vulnerable (2.34-0ubuntu3)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Does not exist"
                            ],
                            [
                                "Patches:",
                                "Upstream: Upstream:"
                            ]
                        ]
                    },
                    "notes": [
                        "21.04 and earlier are not affected due to the fix for\nCVE-2021-33574 having not been introduced yet."
                    ]
                }
            ]
        },
        {
            "name": "CVE-2021-38604",
            "description": "In librt in the GNU C Library (aka glibc) through 2.34, sysdeps/unix/sysv/linux/mq_notify.c mishandles certain NOTIFY_REMOVED data, leading to a NULL pointer dereference. NOTE: this vulnerability was introduced as a side effect of the CVE-2021-33574 fix.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-38604",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.23-0ubuntu11.3"
                },
                {
                    "key": "package_name",
                    "value": "glibc"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "glibc",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Pending (2.35)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Not vulnerable (2.34-0ubuntu3)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Does not exist"
                            ],
                            [
                                "Patches:",
                                "Upstream: Upstream:"
                            ]
                        ]
                    },
                    "notes": [
                        "21.04 and earlier are not affected due to the fix for\nCVE-2021-33574 having not been introduced yet."
                    ]
                }
            ]
        }
    ],
    "imagemagick": [
        {
            "name": "CVE-2020-25664",
            "description": "In WriteOnePNGImage() of the PNG coder at coders/png.c, an improper call to AcquireVirtualMemory() and memset() allows for an out-of-bounds write later when PopShortPixel() from MagickCore/quantum-private.h is called. The patch fixes the calls by adding 256 to rowbytes. An attacker who is able to supply a specially crafted image could affect availability with a low impact to data integrity. This flaw affects ImageMagick versions prior to 6.9.10-68 and 7.0.8-68.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-25664",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "8:6.8.9.9-7ubuntu5.16"
                },
                {
                    "key": "package_name",
                    "value": "imagemagick"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:N/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "imagemagick",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (8:6.9.11.24+dfsg-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Does not exist"
                            ],
                            [
                                "Patches:",
                                "Upstream: Upstream:"
                            ]
                        ]
                    },
                    "notes": [
                        "fix attempt was reverted\nunclear what the fix for this issue is as of 2021-06-10"
                    ]
                }
            ]
        },
        {
            "name": "CVE-2020-27752",
            "description": "A flaw was found in ImageMagick in MagickCore/quantum-private.h. An attacker who submits a crafted file that is processed by ImageMagick could trigger a heap buffer overflow. This would most likely lead to an impact to application availability, but could potentially lead to an impact to data integrity as well. This flaw affects ImageMagick versions prior to 7.0.9-0.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-27752",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "8:6.8.9.9-7ubuntu5.16"
                },
                {
                    "key": "package_name",
                    "value": "imagemagick"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:N/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "imagemagick",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (8:6.9.11.24+dfsg-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Not vulnerable (8:6.9.11.60+dfsg-1ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Does not exist"
                            ]
                        ]
                    },
                    "notes": [
                        "need to clarify exact patch, see Debian comment on upstream bug"
                    ]
                }
            ]
        }
    ],
    "krb5": [
        {
            "name": "CVE-2018-20217",
            "description": "A Reachable Assertion issue was discovered in the KDC in MIT Kerberos 5 (aka krb5) before 1.17. If an attacker can obtain a krbtgt ticket using an older encryption type (single-DES, triple-DES, or RC4), the attacker can crash the KDC by making an S4U2Self request.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20217",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "1.13.2+dfsg-5ubuntu2.2"
                },
                {
                    "key": "package_name",
                    "value": "krb5"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:S/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "3.5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "krb5",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (1.17)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Not vulnerable (1.17-10)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Not vulnerable (1.17-6ubuntu4)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ],
                            [
                                "Binaries built from this source package are in",
                                "and so are supported by the community."
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "libgcrypt20": [
        {
            "name": "CVE-2021-40528",
            "description": "The ElGamal implementation in Libgcrypt before 1.9.4 allows plaintext recovery because, during interaction between two cryptographic libraries, a certain dangerous combination of the prime defined by the receiver's public key, the generator defined by the receiver's public key, and the sender's ephemeral exponents can lead to a cross-configuration attack against OpenPGP.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-40528",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "1.6.5-2ubuntu0.6"
                },
                {
                    "key": "package_name",
                    "value": "libgcrypt20"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:H/Au:N/C:P/I:N/A:N"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "2.6"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libgcrypt20",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (1.9.4-2)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (1.8.7-5ubuntu2)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (1.8.5-5ubuntu1.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (1.8.1-4ubuntu1.3)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (1.6.5-2ubuntu0.6+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Does not exist"
                            ],
                            [
                                "Patches:",
                                "Upstream: Upstream:"
                            ]
                        ]
                    },
                    "notes": [
                        "The commits below reference CVE-2021-33560, but they appear to\nactually be for this CVE, which was issued later. The original\nCVE was switched later on to the exponent blinding issue\ninstead."
                    ]
                }
            ]
        }
    ],
    "libgd2": [
        {
            "name": "CVE-2021-40145",
            "description": "** DISPUTED ** gdImageGd2Ptr in gd_gd2.c in the GD Graphics Library (aka LibGD) through 2.3.2 has a double free. NOTE: the vendor's position is \"The GD2 image format is a proprietary image format of libgd. It has to be regarded as being obsolete, and should only be used for development and testing purposes.\"",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-40145",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.1.1-4ubuntu0.16.04.12"
                },
                {
                    "key": "package_name",
                    "value": "libgd2"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libgd2",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2.3.0-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.2.5-5.2ubuntu2.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.2.5-4ubuntu0.5)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.1.1-4ubuntu0.16.04.12+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (2.1.0-3ubuntu0.11+esm2)"
                            ]
                        ]
                    },
                    "notes": [
                        "php uses the system libgd2"
                    ]
                }
            ]
        }
    ],
    "libwebp": [
        {
            "name": "CVE-2020-36329",
            "description": "A flaw was found in libwebp in versions before 1.0.1. A use-after-free was found due to a thread being killed too early. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36329",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "0.4.4-1"
                },
                {
                    "key": "package_name",
                    "value": "libwebp"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "7.5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libwebp",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (0.6.1-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (0.6.1-2ubuntu0.20.04.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (0.6.1-2ubuntu0.18.04.1)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (0.4.4-1ubuntu0.1~esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (0.4.0-4ubuntu0.1~esm1)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2018-25011",
            "description": "A flaw was found in libwebp in versions before 1.0.1. A heap-based buffer overflow was found in PutLE16(). The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25011",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "0.4.4-1"
                },
                {
                    "key": "package_name",
                    "value": "libwebp"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "7.5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libwebp",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (0.6.1-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (0.6.1-2ubuntu0.20.04.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (0.6.1-2ubuntu0.18.04.1)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (0.4.4-1ubuntu0.1~esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (0.4.0-4ubuntu0.1~esm1)"
                            ],
                            [
                                "Patches:",
                                "Upstream: Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2018-25013",
            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function ShiftBytes. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25013",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "0.4.4-1"
                },
                {
                    "key": "package_name",
                    "value": "libwebp"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.4"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libwebp",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (0.6.1-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (0.6.1-2ubuntu0.20.04.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (0.6.1-2ubuntu0.18.04.1)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (0.4.4-1ubuntu0.1~esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (0.4.0-4ubuntu0.1~esm1)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2020-36331",
            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function ChunkAssignData. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36331",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "0.4.4-1"
                },
                {
                    "key": "package_name",
                    "value": "libwebp"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.4"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libwebp",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (0.6.1-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (0.6.1-2ubuntu0.20.04.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (0.6.1-2ubuntu0.18.04.1)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (0.4.4-1ubuntu0.1~esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (0.4.0-4ubuntu0.1~esm1)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2018-25012",
            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function WebPMuxCreateInternal. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25012",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "0.4.4-1"
                },
                {
                    "key": "package_name",
                    "value": "libwebp"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.4"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libwebp",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (0.6.1-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (0.6.1-2ubuntu0.20.04.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (0.6.1-2ubuntu0.18.04.1)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (0.4.4-1ubuntu0.1~esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (0.4.0-4ubuntu0.1~esm1)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": [
                        "same commit as CVE-2018-25009"
                    ]
                }
            ]
        },
        {
            "name": "CVE-2020-36330",
            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function ChunkVerifyAndAssign. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36330",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "0.4.4-1"
                },
                {
                    "key": "package_name",
                    "value": "libwebp"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.4"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libwebp",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (0.6.1-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (0.6.1-2ubuntu0.20.04.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (0.6.1-2ubuntu0.18.04.1)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (0.4.4-1ubuntu0.1~esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (0.4.0-4ubuntu0.1~esm1)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2018-25014",
            "description": "A flaw was found in libwebp in versions before 1.0.1. An unitialized variable is used in function ReadSymbol. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25014",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "0.4.4-1"
                },
                {
                    "key": "package_name",
                    "value": "libwebp"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "7.5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libwebp",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (0.6.1-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (0.6.1-2ubuntu0.20.04.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (0.6.1-2ubuntu0.18.04.1)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (0.4.4-1ubuntu0.1~esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (0.4.0-4ubuntu0.1~esm1)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2020-36328",
            "description": "A flaw was found in libwebp in versions before 1.0.1. A heap-based buffer overflow in function WebPDecodeRGBInto is possible due to an invalid check for buffer size. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36328",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "0.4.4-1"
                },
                {
                    "key": "package_name",
                    "value": "libwebp"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "7.5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libwebp",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (0.6.1-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (0.6.1-2ubuntu0.20.04.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (0.6.1-2ubuntu0.18.04.1)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (0.4.4-1ubuntu0.1~esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (0.4.0-4ubuntu0.1~esm1)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2018-25009",
            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function WebPMuxCreateInternal. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25009",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "0.4.4-1"
                },
                {
                    "key": "package_name",
                    "value": "libwebp"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.4"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libwebp",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (0.6.1-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (0.6.1-2ubuntu0.20.04.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (0.6.1-2ubuntu0.18.04.1)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (0.4.4-1ubuntu0.1~esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (0.4.0-4ubuntu0.1~esm1)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2018-25010",
            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function ApplyFilter. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25010",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "0.4.4-1"
                },
                {
                    "key": "package_name",
                    "value": "libwebp"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.4"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libwebp",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (0.6.1-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (0.6.1-2ubuntu0.20.04.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (0.6.1-2ubuntu0.18.04.1)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (0.4.4-1ubuntu0.1~esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (0.4.0-4ubuntu0.1~esm1)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "libx11": [
        {
            "name": "CVE-2021-31535",
            "description": "LookupCol.c in X.Org X through X11R7.7 and libX11 before 1.7.1 might allow remote attackers to execute arbitrary code. The libX11 XLookupColor request (intended for server-side color lookup) contains a flaw allowing a client to send color-name requests with a name longer than the maximum size allowed by the protocol (and also longer than the maximum packet size for normal-sized packets). The user-controlled data exceeding the maximum size is then interpreted by the server as additional X protocol requests and executed, e.g., to disable X server authorization completely. For example, if the victim encounters malicious terminal control sequences for color codes, then the attacker may be able to take full control of the running graphical session.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-31535",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2:1.6.3-1ubuntu2.2"
                },
                {
                    "key": "package_name",
                    "value": "libx11"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "7.5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libx11",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (1.7.0-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2:1.6.9-2ubuntu1.2)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2:1.6.4-3ubuntu0.4)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2:1.6.3-1ubuntu2.2+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (2:1.6.2-1ubuntu2.1+esm2)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "libxml2": [
        {
            "name": "CVE-2021-3518",
            "description": "There's a flaw in libxml2 in versions before 2.9.11. An attacker who is able to submit a crafted file to be processed by an application linked with libxml2 could trigger a use-after-free. The greatest impact from this flaw is to confidentiality, integrity, and availability.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3518",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.9.3+dfsg1-1ubuntu0.7"
                },
                {
                    "key": "package_name",
                    "value": "libxml2"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libxml2",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.9.10+dfsg-6.6)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Not vulnerable (2.9.10+dfsg-6.7)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.9.4+dfsg1-6.1ubuntu1.4)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (2.9.1+dfsg1-3ubuntu4.13+esm2)"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2021-3517",
            "description": "There is a flaw in the xml entity encoding functionality of libxml2 in versions before 2.9.11. An attacker who is able to supply a crafted file to be processed by an application linked with the affected functionality of libxml2 could trigger an out-of-bounds read. The most likely impact of this flaw is to application availability, with some potential impact to confidentiality and integrity if an attacker is able to use memory information to further exploit the application.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3517",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.9.3+dfsg1-1ubuntu0.7"
                },
                {
                    "key": "package_name",
                    "value": "libxml2"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "7.5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libxml2",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.9.10+dfsg-6.6)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Not vulnerable (2.9.10+dfsg-6.7)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.9.4+dfsg1-6.1ubuntu1.4)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (2.9.1+dfsg1-3ubuntu4.13+esm2)"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2021-3537",
            "description": "A vulnerability found in libxml2 in versions before 2.9.11 shows that it did not propagate errors while parsing XML mixed content, causing a NULL dereference. If an untrusted XML document was parsed in recovery mode and post-validated, the flaw could be used to crash the application. The highest threat from this vulnerability is to system availability.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3537",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.9.3+dfsg1-1ubuntu0.7"
                },
                {
                    "key": "package_name",
                    "value": "libxml2"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "4.3"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libxml2",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.9.10+dfsg-6.6)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Not vulnerable (2.9.10+dfsg-6.7)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.9.4+dfsg1-6.1ubuntu1.4)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (2.9.1+dfsg1-3ubuntu4.13+esm2)"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2021-3516",
            "description": "There's a flaw in libxml2's xmllint in versions before 2.9.11. An attacker who is able to submit a crafted file to be processed by xmllint could trigger a use-after-free. The greatest impact of this flaw is to confidentiality, integrity, and availability.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3516",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.9.3+dfsg1-1ubuntu0.7"
                },
                {
                    "key": "package_name",
                    "value": "libxml2"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "libxml2",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.9.10+dfsg-6.6)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Not vulnerable (2.9.10+dfsg-6.7)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.9.4+dfsg1-6.1ubuntu1.4)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (2.9.1+dfsg1-3ubuntu4.13+esm2)"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "lz4": [
        {
            "name": "CVE-2021-3520",
            "description": "There's a flaw in lz4. An attacker who submits a crafted file to an application linked with lz4 may be able to trigger an integer overflow, leading to calling of memmove() on a negative size argument, causing an out-of-bounds write and/or a crash. The greatest impact of this flaw is to availability, with some potential impact to confidentiality and integrity as well.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3520",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "0.0~r131-2ubuntu2"
                },
                {
                    "key": "package_name",
                    "value": "lz4"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "7.5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "lz4",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (1.9.3-2)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Not vulnerable (1.9.3-2)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (1.9.2-2ubuntu0.20.04.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (0.0~r131-2ubuntu3.1)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (0.0~r131-2ubuntu2+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (0.0~r114-2ubuntu1+esm2)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "nettle": [
        {
            "name": "CVE-2021-20305",
            "description": "A flaw was found in Nettle in versions before 3.7.2, where several Nettle signature verification functions (GOST DSA, EDDSA & ECDSA) result in the Elliptic Curve Cryptography point (ECC) multiply function being called with out-of-range scalers, possibly resulting in incorrect results. This flaw allows an attacker to force an invalid signature, causing an assertion failure or possible validation. The highest threat to this vulnerability is to confidentiality, integrity, as well as system availability.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-20305",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "3.2-1ubuntu0.16.04.1"
                },
                {
                    "key": "package_name",
                    "value": "nettle"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "nettle",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (3.7.2-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (3.7-2.1ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (3.5.1+really3.5.1-2ubuntu0.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (3.4-1ubuntu0.1)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (3.2-1ubuntu0.16.04.2)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needs triage"
                            ],
                            [
                                "Patches:",
                                "Upstream: Upstream: Upstream: Upstream: Upstream: Upstream: Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "openexr": [
        {
            "name": "CVE-2021-3605",
            "description": "There's a flaw in OpenEXR's rleUncompress functionality in versions prior to 3.0.5. An attacker who is able to submit a crafted file to an application linked with OpenEXR could cause an out-of-bounds read. The greatest risk from this flaw is to application availability.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3605",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.2.0-10ubuntu2.6"
                },
                {
                    "key": "package_name",
                    "value": "openexr"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "4.3"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openexr",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.5.7-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.2.0-11.1ubuntu1.7)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.2.0-10ubuntu2.6+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Does not exist"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2021-3933",
            "description": "openexr: Integer-overflow in Imf_3_1::bytesPerDeepLineTable",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3933",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.2.0-10ubuntu2.6"
                },
                {
                    "key": "package_name",
                    "value": "openexr"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openexr",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.2.0-11.1ubuntu1.8)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.2.0-10ubuntu2.6+esm2)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Ignored (out of standard support)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "openldap": [
        {
            "name": "CVE-2020-36225",
            "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to a double free and slapd crash in the saslAuthzTo processing, resulting in denial of service.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36225",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.4.42+dfsg-2ubuntu3.11"
                },
                {
                    "key": "package_name",
                    "value": "openldap"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openldap",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.4.57+dfsg-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2.4.57+dfsg-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.4.49+dfsg-2ubuntu1.6)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.4.45+dfsg-1ubuntu1.9)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.4.42+dfsg-2ubuntu3.12)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2020-36223",
            "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to a slapd crash in the Values Return Filter control handling, resulting in denial of service (double free and out-of-bounds read).",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36223",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.4.42+dfsg-2ubuntu3.11"
                },
                {
                    "key": "package_name",
                    "value": "openldap"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openldap",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.4.57+dfsg-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2.4.57+dfsg-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.4.49+dfsg-2ubuntu1.6)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.4.45+dfsg-1ubuntu1.9)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.4.42+dfsg-2ubuntu3.12)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2020-36230",
            "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading in an assertion failure in slapd in the X.509 DN parsing in decode.c ber_next_element, resulting in denial of service.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36230",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.4.42+dfsg-2ubuntu3.11"
                },
                {
                    "key": "package_name",
                    "value": "openldap"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openldap",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.4.57+dfsg-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2.4.57+dfsg-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.4.49+dfsg-2ubuntu1.6)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.4.45+dfsg-1ubuntu1.9)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.4.42+dfsg-2ubuntu3.12)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2020-36226",
            "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to a memch->bv_len miscalculation and slapd crash in the saslAuthzTo processing, resulting in denial of service.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36226",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.4.42+dfsg-2ubuntu3.11"
                },
                {
                    "key": "package_name",
                    "value": "openldap"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openldap",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.4.57+dfsg-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2.4.57+dfsg-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.4.49+dfsg-2ubuntu1.6)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.4.45+dfsg-1ubuntu1.9)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.4.42+dfsg-2ubuntu3.12)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2020-36228",
            "description": "An integer underflow was discovered in OpenLDAP before 2.4.57 leading to a slapd crash in the Certificate List Exact Assertion processing, resulting in denial of service.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36228",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.4.42+dfsg-2ubuntu3.11"
                },
                {
                    "key": "package_name",
                    "value": "openldap"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openldap",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.4.57+dfsg-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2.4.57+dfsg-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.4.49+dfsg-2ubuntu1.6)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.4.45+dfsg-1ubuntu1.9)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.4.42+dfsg-2ubuntu3.12)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2020-36229",
            "description": "A flaw was discovered in ldap_X509dn2bv in OpenLDAP before 2.4.57 leading to a slapd crash in the X.509 DN parsing in ad_keystring, resulting in denial of service.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36229",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.4.42+dfsg-2ubuntu3.11"
                },
                {
                    "key": "package_name",
                    "value": "openldap"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openldap",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.4.57+dfsg-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2.4.57+dfsg-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.4.49+dfsg-2ubuntu1.6)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.4.45+dfsg-1ubuntu1.9)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.4.42+dfsg-2ubuntu3.12)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2020-36221",
            "description": "An integer underflow was discovered in OpenLDAP before 2.4.57 leading to slapd crashes in the Certificate Exact Assertion processing, resulting in denial of service (schema_init.c serialNumberAndIssuerCheck).",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36221",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.4.42+dfsg-2ubuntu3.11"
                },
                {
                    "key": "package_name",
                    "value": "openldap"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openldap",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.4.57+dfsg-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2.4.57+dfsg-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.4.49+dfsg-2ubuntu1.6)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.4.45+dfsg-1ubuntu1.9)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.4.42+dfsg-2ubuntu3.12)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ],
                            [
                                "Patches:",
                                "Upstream: Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2020-36222",
            "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to an assertion failure in slapd in the saslAuthzTo validation, resulting in denial of service.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36222",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.4.42+dfsg-2ubuntu3.11"
                },
                {
                    "key": "package_name",
                    "value": "openldap"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openldap",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.4.57+dfsg-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2.4.57+dfsg-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.4.49+dfsg-2ubuntu1.6)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.4.45+dfsg-1ubuntu1.9)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.4.42+dfsg-2ubuntu3.12)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ],
                            [
                                "Patches:",
                                "Upstream: Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2020-36227",
            "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to an infinite loop in slapd with the cancel_extop Cancel operation, resulting in denial of service.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36227",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.4.42+dfsg-2ubuntu3.11"
                },
                {
                    "key": "package_name",
                    "value": "openldap"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openldap",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.4.57+dfsg-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2.4.57+dfsg-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.4.49+dfsg-2ubuntu1.6)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.4.45+dfsg-1ubuntu1.9)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.4.42+dfsg-2ubuntu3.12)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2021-27212",
            "description": "In OpenLDAP through 2.4.57 and 2.5.x through 2.5.1alpha, an assertion failure in slapd can occur in the issuerAndThisUpdateCheck function via a crafted packet, resulting in a denial of service (daemon exit) via a short timestamp. This is related to schema_init.c and checkTime.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-27212",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.4.42+dfsg-2ubuntu3.11"
                },
                {
                    "key": "package_name",
                    "value": "openldap"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openldap",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.4.57+dfsg-2)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2.4.57+dfsg-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.4.49+dfsg-2ubuntu1.7)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.4.45+dfsg-1ubuntu1.10)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.4.42+dfsg-2ubuntu3.13)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ],
                            [
                                "Patches:",
                                "Upstream: Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2020-36224",
            "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to an invalid pointer free and slapd crash in the saslAuthzTo processing, resulting in denial of service.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36224",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2.4.42+dfsg-2ubuntu3.11"
                },
                {
                    "key": "package_name",
                    "value": "openldap"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openldap",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (2.4.57+dfsg-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2.4.57+dfsg-2ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2.4.49+dfsg-2ubuntu1.6)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2.4.45+dfsg-1ubuntu1.9)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2.4.42+dfsg-2ubuntu3.12)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ],
                            [
                                "Patches:",
                                "Upstream: Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "openssl": [
        {
            "name": "CVE-2021-23841",
            "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-23841",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "1.0.2g-1ubuntu4.18"
                },
                {
                    "key": "package_name",
                    "value": "openssl"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "4.3"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openssl",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (1.1.1j)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (1.1.1f-1ubuntu2.2)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (1.1.1-1ubuntu2.1~18.04.8)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (1.0.2g-1ubuntu4.19)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (1.0.1f-1ubuntu2.27+esm2)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": [
                        "edk2 doesn't use the affected function"
                    ]
                }
            ]
        },
        {
            "name": "CVE-2021-3712",
            "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3712",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "1.0.2g-1ubuntu4.18"
                },
                {
                    "key": "package_name",
                    "value": "openssl"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:P/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openssl",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (1.1.1l-1ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (1.1.1f-1ubuntu2.8)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (1.1.1-1ubuntu2.1~18.04.13)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (1.0.2g-1ubuntu4.20+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (1.0.1f-1ubuntu2.27+esm4)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": [
                        "in 1.0.2, this bug is in X509_CERT_AUX_print()\nlist of commits below is incomplete"
                    ]
                }
            ]
        },
        {
            "name": "CVE-2021-3712",
            "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3712",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "1.0.2g-1ubuntu4.20"
                },
                {
                    "key": "package_name",
                    "value": "openssl"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:P/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "openssl",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (1.1.1l-1ubuntu1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (1.1.1f-1ubuntu2.8)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (1.1.1-1ubuntu2.1~18.04.13)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (1.0.2g-1ubuntu4.20+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (1.0.1f-1ubuntu2.27+esm4)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": [
                        "in 1.0.2, this bug is in X509_CERT_AUX_print()\nlist of commits below is incomplete"
                    ]
                }
            ]
        }
    ],
    "p11-kit": [
        {
            "name": "CVE-2020-29361",
            "description": "An issue was discovered in p11-kit 0.21.1 through 0.23.21. Multiple integer overflows have been discovered in the array allocations in the p11-kit library and the p11-kit list command, where overflow checks are missing before calling realloc or calloc.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-29361",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "0.23.2-5~ubuntu16.04.1"
                },
                {
                    "key": "package_name",
                    "value": "p11-kit"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "p11-kit",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (0.23.22-1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (0.23.20-1ubuntu0.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (0.23.9-2ubuntu0.1)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (0.23.2-5~ubuntu16.04.2)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (0.20.2-2ubuntu2+esm1)"
                            ],
                            [
                                "Patches:",
                                "Upstream: Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2020-29362",
            "description": "An issue was discovered in p11-kit 0.21.1 through 0.23.21. A heap-based buffer over-read has been discovered in the RPC protocol used by thep11-kit server/remote commands and the client library. When the remote entity supplies a byte array through a serialized PKCS#11 function call, the receiving entity may allow the reading of up to 4 bytes of memory past the heap allocation.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-29362",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "0.23.2-5~ubuntu16.04.1"
                },
                {
                    "key": "package_name",
                    "value": "p11-kit"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:N"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "p11-kit",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (0.23.22-1)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (0.23.22-1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (0.23.20-1ubuntu0.1)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (0.23.9-2ubuntu0.1)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (0.23.2-5~ubuntu16.04.2)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Not vulnerable (code not present)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "perl": [
        {
            "name": "CVE-2020-16156",
            "description": "CPAN 2.28 allows Signature Verification Bypass.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-16156",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "5.22.1-9ubuntu0.9"
                },
                {
                    "key": "package_name",
                    "value": "perl"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "perl",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needed"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ]
                        ]
                    },
                    "notes": [
                        "Fix is in cpanpm 2.29"
                    ]
                }
            ]
        }
    ],
    "python3.5": [
        {
            "name": "CVE-2021-3737",
            "description": "[client can enter an infinite loop on a 100 Continue response from the server]",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3737",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "3.5.2-2ubuntu0~16.04.13"
                },
                {
                    "key": "package_name",
                    "value": "python3.5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "python3.5",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Does not exist"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Does not exist"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Does not exist"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (3.5.2-2ubuntu0~16.04.13+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ]
                        ]
                    },
                    "notes": [
                        "impish/devel is not affected, code supposed affected was patched already."
                    ]
                }
            ]
        },
        {
            "name": "CVE-2021-3733",
            "description": "[Denial of service when identifying crafted invalid RFCs]",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3733",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "3.5.2-2ubuntu0~16.04.13"
                },
                {
                    "key": "package_name",
                    "value": "python3.5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "python3.5",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Does not exist"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Does not exist"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Does not exist"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (3.5.2-2ubuntu0~16.04.13+esm1)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ]
                        ]
                    },
                    "notes": [
                        "code affected in hirsute and devel is already patched, so both releases\nin python3.9 are not affected."
                    ]
                }
            ]
        },
        {
            "name": "CVE-2021-4189",
            "description": "[ftplib should not use the host from the PASV response]",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-4189",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "3.5.2-2ubuntu0~16.04.13"
                },
                {
                    "key": "package_name",
                    "value": "python3.5"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "python3.5",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needed"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Does not exist"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Does not exist"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Does not exist"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "sqlite3": [
        {
            "name": "CVE-2020-9794",
            "description": "An out-of-bounds read was addressed with improved bounds checking. This issue is fixed in iOS 13.5 and iPadOS 13.5, macOS Catalina 10.15.5, tvOS 13.4.5, watchOS 6.2.5, iTunes 12.10.7 for Windows, iCloud for Windows 11.2, iCloud for Windows 7.19. A malicious application may cause a denial of service or potentially disclose memory contents.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-9794",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "3.11.0-1ubuntu1.5"
                },
                {
                    "key": "package_name",
                    "value": "sqlite3"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:P/I:N/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "sqlite3",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Deferred"
                            ]
                        ]
                    },
                    "notes": [
                        "This may be an Apple-specific CVE, as of 2021-02-08, no details\nare available as to what the upstream fix is."
                    ]
                }
            ]
        }
    ],
    "vim": [
        {
            "name": "CVE-2021-3984",
            "description": "vim is vulnerable to Heap-based Buffer Overflow",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3984",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2:7.4.1689-3ubuntu1.5"
                },
                {
                    "key": "package_name",
                    "value": "vim"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "vim",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (v8.2.3625)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2:8.2.2434-3ubuntu3.2)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2:8.1.2269-1ubuntu5.6)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2:8.0.1453-1ubuntu1.8)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ]
                        ]
                    },
                    "notes": [
                        "for bionic and earlier, the vulnerable function in src/cindent.c\nis in src/misc1.c."
                    ]
                }
            ]
        },
        {
            "name": "CVE-2021-4069",
            "description": "vim is vulnerable to Use After Free",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-4069",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2:7.4.1689-3ubuntu1.5"
                },
                {
                    "key": "package_name",
                    "value": "vim"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "vim",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (v8.2.3761)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2:8.2.2434-3ubuntu3.2)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2:8.1.2269-1ubuntu5.6)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2:8.0.1453-1ubuntu1.8)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2022-0351",
            "description": "Access of Memory Location Before Start of Buffer in Conda vim prior to 8.2.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-0351",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2:7.4.1689-3ubuntu1.5"
                },
                {
                    "key": "package_name",
                    "value": "vim"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:L/AC:L/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "4.6"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "vim",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2021-3796",
            "description": "vim is vulnerable to Use After Free",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3796",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2:7.4.1689-3ubuntu1.5"
                },
                {
                    "key": "package_name",
                    "value": "vim"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "vim",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (v8.2.3428)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2:8.2.2434-3ubuntu2)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2:8.1.2269-1ubuntu5.3)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2:8.0.1453-1ubuntu1.6)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2:7.4.1689-3ubuntu1.5+esm2)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (2:7.4.052-1ubuntu3.1+esm3)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2021-4019",
            "description": "vim is vulnerable to Heap-based Buffer Overflow",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-4019",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2:7.4.1689-3ubuntu1.5"
                },
                {
                    "key": "package_name",
                    "value": "vim"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "vim",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (v8.2.3669)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2:8.2.2434-3ubuntu3.2)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2:8.1.2269-1ubuntu5.6)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2:8.0.1453-1ubuntu1.8)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ]
                        ]
                    },
                    "notes": [
                        "in focal and earlier vulnerable function from src/help.c\nis in src/ex_cmds.c."
                    ]
                }
            ]
        },
        {
            "name": "CVE-2021-3928",
            "description": "vim is vulnerable to Use of Uninitialized Variable",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3928",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2:7.4.1689-3ubuntu1.5"
                },
                {
                    "key": "package_name",
                    "value": "vim"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:L/AC:L/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "4.6"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "vim",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (v8.2.3582)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2:8.2.2434-3ubuntu3.1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2:8.1.2269-1ubuntu5.4)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2:8.0.1453-1ubuntu1.7)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2:7.4.1689-3ubuntu1.5+esm3)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (2:7.4.052-1ubuntu3.1+esm4)"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2021-3927",
            "description": "vim is vulnerable to Heap-based Buffer Overflow",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3927",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2:7.4.1689-3ubuntu1.5"
                },
                {
                    "key": "package_name",
                    "value": "vim"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "vim",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (v8.2.3581)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2:8.2.2434-3ubuntu3.1)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2:8.1.2269-1ubuntu5.4)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2:8.0.1453-1ubuntu1.7)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2:7.4.1689-3ubuntu1.5+esm3)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (2:7.4.052-1ubuntu3.1+esm4)"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2022-0359",
            "description": "Heap-based Buffer Overflow in Conda vim prior to 8.2.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-0359",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2:7.4.1689-3ubuntu1.5"
                },
                {
                    "key": "package_name",
                    "value": "vim"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "vim",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2021-3778",
            "description": "vim is vulnerable to Heap-based Buffer Overflow",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3778",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2:7.4.1689-3ubuntu1.5"
                },
                {
                    "key": "package_name",
                    "value": "vim"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "6.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "vim",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Released (v8.2.3409)"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Released (2:8.2.2434-3ubuntu2)"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Released (2:8.1.2269-1ubuntu5.3)"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Released (2:8.0.1453-1ubuntu1.6)"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Released (2:7.4.1689-3ubuntu1.5+esm2)"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Released (2:7.4.052-1ubuntu3.1+esm3)"
                            ],
                            [
                                "Patches:",
                                "Upstream:"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        },
        {
            "name": "CVE-2022-0361",
            "description": "Heap-based Buffer Overflow in Conda vim prior to 8.2.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-0361",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "2:7.4.1689-3ubuntu1.5"
                },
                {
                    "key": "package_name",
                    "value": "vim"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "vim",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Needed"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Needed"
                            ]
                        ]
                    },
                    "notes": []
                }
            ]
        }
    ],
    "wget": [
        {
            "name": "CVE-2021-31879",
            "description": "GNU Wget through 1.21.1 does not omit the Authorization header upon a redirect to a different origin, a related issue to CVE-2018-1000007.",
            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-31879",
            "severity": "MEDIUM",
            "attributes": [
                {
                    "key": "package_version",
                    "value": "1.17.1-1ubuntu1.5"
                },
                {
                    "key": "package_name",
                    "value": "wget"
                },
                {
                    "key": "CVSS2_VECTOR",
                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:N"
                },
                {
                    "key": "CVSS2_SCORE",
                    "value": "5.8"
                }
            ],
            "scraped_data": [
                {
                    "status_table": {
                        "packages": [
                            "wget",
                            "Launchpad",
                            "Ubuntu",
                            "Debian"
                        ],
                        "release_states": [
                            [
                                "Upstream",
                                "Needs triage"
                            ],
                            [
                                "Ubuntu 21.10 (Impish Indri)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 20.04 LTS (Focal Fossa)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 18.04 LTS (Bionic Beaver)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 16.04 ESM (Xenial Xerus)",
                                "Deferred"
                            ],
                            [
                                "Ubuntu 14.04 ESM (Trusty Tahr)",
                                "Deferred"
                            ]
                        ]
                    },
                    "notes": [
                        "no upstream fix as of 2022-01-05\nalso see previous upstream bug from 2019"
                    ]
                }
            ]
        }
    ]
}
```

