### PR TITLE
[SecurityUpdate] mxnet inference docker 1.8 py3 cu110 Dockerfile.gpu

### DIFF
--- a/mxnet/inference/docker/1.8/py3/cu110/Dockerfile.gpu.os_scan_allowlist.json
+++ b/mxnet/inference/docker/1.8/py3/cu110/Dockerfile.gpu.os_scan_allowlist.json
@@ -1,10 +1,6 @@
 {
     "apparmor": [
         {
-            "name": "CVE-2016-1585",
-            "description": "In all versions of AppArmor mount rules are accidentally widened when compiled.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-1585",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -23,8 +19,13 @@
                     "value": "7.5"
                 }
             ],
+            "description": "In all versions of AppArmor mount rules are accidentally widened when compiled.",
+            "name": "CVE-2016-1585",
             "scraped_data": [
                 {
+                    "notes": [
+                        "no fix as of 2020-10-19"
+                    ],
                     "status_table": {
                         "packages": [
                             "apparmor",
@@ -34,44 +35,75 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
+                                "artful",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "bionic",
+                                "Deferred"
+                            ],
+                            [
+                                "cosmic",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "disco",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "eoan",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "focal",
+                                "Deferred"
+                            ],
+                            [
+                                "groovy",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
+                                "Deferred"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was deferred)"
+                            ],
+                            [
+                                "trusty",
+                                "Deferred"
+                            ],
+                            [
+                                "upstream",
                                 "Needs triage"
                             ],
                             [
-                                "Ubuntu 21.10 (Impish Indri)",
+                                "xenial",
                                 "Deferred"
                             ],
                             [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Deferred"
+                                "yakkety",
+                                "Ignored (reached end-of-life)"
                             ],
                             [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Deferred"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Deferred"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Deferred"
+                                "zesty",
+                                "Ignored (reached end-of-life)"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "no fix as of 2020-10-19"
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-1585"
         }
     ],
     "apt": [
         {
-            "name": "CVE-2020-27350",
-            "description": "APT had several integer overflows and underflows while parsing .deb packages, aka GHSL-2020-168 GHSL-2020-169, in files apt-pkg/contrib/extracttar.cc, apt-pkg/deb/debfile.cc, and apt-pkg/contrib/arfile.cc. This issue affects: apt 1.2.32ubuntu0 versions prior to 1.2.32ubuntu0.2; 1.6.12ubuntu0 versions prior to 1.6.12ubuntu0.2; 2.0.2ubuntu0 versions prior to 2.0.2ubuntu0.2; 2.1.10ubuntu0 versions prior to 2.1.10ubuntu0.1;",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-27350",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -90,8 +122,11 @@
                     "value": "4.6"
                 }
             ],
+            "description": "APT had several integer overflows and underflows while parsing .deb packages, aka GHSL-2020-168 GHSL-2020-169, in files apt-pkg/contrib/extracttar.cc, apt-pkg/deb/debfile.cc, and apt-pkg/contrib/arfile.cc. This issue affects: apt 1.2.32ubuntu0 versions prior to 1.2.32ubuntu0.2; 1.6.12ubuntu0 versions prior to 1.6.12ubuntu0.2; 2.0.2ubuntu0 versions prior to 2.0.2ubuntu0.2; 2.1.10ubuntu0 versions prior to 2.1.10ubuntu0.1;",
+            "name": "CVE-2020-27350",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "apt",
@@ -101,38 +136,47 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.0.2ubuntu0.2)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (1.6.12ubuntu0.2)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (1.2.32ubuntu0.2)"
+                                "focal",
+                                "Released (2.0.2ubuntu0.2)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (2.1.10ubuntu0.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.1.13)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needs-triage)"
+                            ],
+                            [
+                                "trusty",
                                 "Released (1.0.1ubuntu2.24+esm3)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (1.2.32ubuntu0.2)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-27350"
         }
     ],
     "avahi": [
         {
-            "name": "CVE-2021-3468",
-            "description": "A flaw was found in avahi in versions 0.6 up to 0.8. The event used to signal the termination of the client connection on the avahi Unix socket is not correctly handled in the client_work function, allowing a local attacker to trigger an infinite loop. The highest threat from this vulnerability is to the availability of the avahi service, which becomes unresponsive after this flaw is triggered.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3468",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -151,8 +195,13 @@
                     "value": "2.1"
                 }
             ],
+            "description": "A flaw was found in avahi in versions 0.6 up to 0.8. The event used to signal the termination of the client connection on the avahi Unix socket is not correctly handled in the client_work function, allowing a local attacker to trigger an infinite loop. The highest threat from this vulnerability is to the availability of the avahi service, which becomes unresponsive after this flaw is triggered.",
+            "name": "CVE-2021-3468",
             "scraped_data": [
                 {
+                    "notes": [
+                        "as of 2021-07-06, the proposed patch has not been commited\nupstream"
+                    ],
                     "status_table": {
                         "packages": [
                             "avahi",
@@ -162,48 +211,51 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (0.8-5ubuntu3)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (0.7-4ubuntu7.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (0.7-3.1ubuntu1.3)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (0.6.32~rc+dfsg-1ubuntu2.3+esm1)"
+                                "focal",
+                                "Released (0.7-4ubuntu7.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (0.8-3ubuntu1.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (0.8-5ubuntu3)"
+                            ],
+                            [
+                                "impish",
+                                "Released (0.8-5ubuntu3)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was deferred [2021-07-06])"
+                            ],
+                            [
+                                "trusty",
                                 "Released (0.6.31-4ubuntu1.3+esm1)"
                             ],
                             [
-                                "Patches:",
-                                "Other:"
+                                "upstream",
+                                "Needed"
+                            ],
+                            [
+                                "xenial",
+                                "Released (0.6.32~rc+dfsg-1ubuntu2.3+esm1)"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "as of 2021-07-06, the proposed patch has not been commited\nupstream"
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3468"
         }
     ],
     "binutils": [
         {
-            "name": "CVE-2019-14250",
-            "description": "An issue was discovered in GNU libiberty, as distributed in GNU Binutils 2.32. simple_object_elf_match in simple-object-elf.c does not check for a zero shstrndx value, leading to an integer overflow and resultant heap-based buffer overflow.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-14250",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -222,8 +274,11 @@
                     "value": "4.3"
                 }
             ],
+            "description": "An issue was discovered in GNU libiberty, as distributed in GNU Binutils 2.32. simple_object_elf_match in simple-object-elf.c does not check for a zero shstrndx value, leading to an integer overflow and resultant heap-based buffer overflow.",
+            "name": "CVE-2019-14250",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "binutils",
@@ -233,44 +288,57 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
+                                "bionic",
+                                "Released (2.30-21ubuntu1~18.04.3)"
+                            ],
+                            [
+                                "disco",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "eoan",
+                                "Not vulnerable (2.33-2ubuntu1)"
+                            ],
+                            [
+                                "focal",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "groovy",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needs-triage)"
+                            ],
+                            [
+                                "trusty",
+                                "Needs triage"
+                            ],
+                            [
+                                "upstream",
                                 "Released (2.33)"
                             ],
                             [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable (2.34-5ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Not vulnerable (2.34-5ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2.30-21ubuntu1~18.04.3)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "xenial",
                                 "Released (2.26.1-1ubuntu1~16.04.8+esm1)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needs triage"
-                            ],
-                            [
-                                "Patches:",
-                                "Other: Vendor:"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-14250"
         },
         {
-            "name": "CVE-2019-14444",
-            "description": "apply_relocations in readelf.c in GNU Binutils 2.32 contains an integer overflow that allows attackers to trigger a write access violation (in byte_put_little_endian function in elfcomm.c) via an ELF file, as demonstrated by readelf.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-14444",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -289,8 +357,11 @@
                     "value": "4.3"
                 }
             ],
+            "description": "apply_relocations in readelf.c in GNU Binutils 2.32 contains an integer overflow that allows attackers to trigger a write access violation (in byte_put_little_endian function in elfcomm.c) via an ELF file, as demonstrated by readelf.",
+            "name": "CVE-2019-14444",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "binutils",
@@ -300,44 +371,57 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (2.32.51.20190813-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable (2.34-5ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Not vulnerable (2.34-5ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (2.30-21ubuntu1~18.04.3)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.26.1-1ubuntu1~16.04.8+esm1)"
+                                "disco",
+                                "Ignored (reached end-of-life)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "eoan",
+                                "Not vulnerable (2.33-2ubuntu1)"
+                            ],
+                            [
+                                "focal",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "groovy",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needs-triage)"
+                            ],
+                            [
+                                "trusty",
                                 "Needed"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Released (2.32.51.20190813-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.26.1-1ubuntu1~16.04.8+esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-14444"
         },
         {
-            "name": "CVE-2019-17451",
-            "description": "An issue was discovered in the Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils 2.32. It is an integer overflow leading to a SEGV in _bfd_dwarf2_find_nearest_line in dwarf2.c, as demonstrated by nm.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17451",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -356,8 +440,11 @@
                     "value": "4.3"
                 }
             ],
+            "description": "An issue was discovered in the Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils 2.32. It is an integer overflow leading to a SEGV in _bfd_dwarf2_find_nearest_line in dwarf2.c, as demonstrated by nm.",
+            "name": "CVE-2019-17451",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "binutils",
@@ -367,46 +454,59 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable (2.34-5ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Not vulnerable (2.34-5ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (2.30-21ubuntu1~18.04.3)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.26.1-1ubuntu1~16.04.8+esm1)"
+                                "disco",
+                                "Ignored (reached end-of-life)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "eoan",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "focal",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "groovy",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Not vulnerable (2.34-5ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needs-triage)"
+                            ],
+                            [
+                                "trusty",
                                 "Needs triage"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.26.1-1ubuntu1~16.04.8+esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17451"
         }
     ],
     "curl": [
         {
-            "name": "CVE-2021-22925",
-            "description": "curl supports the `-t` command line option, known as `CURLOPT_TELNETOPTIONS`in libcurl. This rarely used option is used to send variable=content pairs toTELNET servers.Due to flaw in the option parser for sending `NEW_ENV` variables, libcurlcould be made to pass on uninitialized data from a stack based buffer to theserver. Therefore potentially revealing sensitive internal information to theserver using a clear-text network protocol.This could happen because curl did not call and use sscanf() correctly whenparsing the string provided by the application.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-22925",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -425,8 +525,13 @@
                     "value": "5"
                 }
             ],
+            "description": "curl supports the `-t` command line option, known as `CURLOPT_TELNETOPTIONS`in libcurl. This rarely used option is used to send variable=content pairs toTELNET servers.Due to flaw in the option parser for sending `NEW_ENV` variables, libcurlcould be made to pass on uninitialized data from a stack based buffer to theserver. Therefore potentially revealing sensitive internal information to theserver using a clear-text network protocol.This could happen because curl did not call and use sscanf() correctly whenparsing the string provided by the application.",
+            "name": "CVE-2021-22925",
             "scraped_data": [
                 {
+                    "notes": [
+                        "caused by incomplete fix for CVE-2021-22898"
+                    ],
                     "status_table": {
                         "packages": [
                             "curl",
@@ -436,42 +541,45 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (7.78.0)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (7.74.0-1.2ubuntu4)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (7.68.0-1ubuntu2.6)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (7.58.0-2ubuntu3.14)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (7.47.0-1ubuntu2.19+esm3)"
+                                "focal",
+                                "Released (7.68.0-1ubuntu2.6)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (7.74.0-1ubuntu2.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (7.74.0-1.2ubuntu4)"
+                            ],
+                            [
+                                "trusty",
                                 "Needed"
+                            ],
+                            [
+                                "upstream",
+                                "Released (7.78.0)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (7.47.0-1ubuntu2.19+esm3)"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "caused by incomplete fix for CVE-2021-22898"
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-22925"
         },
         {
-            "name": "CVE-2021-22946",
-            "description": "A user can tell curl >= 7.20.0 and <= 7.78.0 to require a successful upgrade to TLS when speaking to an IMAP, POP3 or FTP server (`--ssl-reqd` on the command line or`CURLOPT_USE_SSL` set to `CURLUSESSL_CONTROL` or `CURLUSESSL_ALL` withlibcurl). This requirement could be bypassed if the server would return a properly crafted but perfectly legitimate response.This flaw would then make curl silently continue its operations **withoutTLS** contrary to the instructions and expectations, exposing possibly sensitive data in clear text over the network.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-22946",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -490,8 +598,13 @@
                     "value": "5"
                 }
             ],
+            "description": "A user can tell curl >= 7.20.0 and <= 7.78.0 to require a successful upgrade to TLS when speaking to an IMAP, POP3 or FTP server (`--ssl-reqd` on the command line or`CURLOPT_USE_SSL` set to `CURLUSESSL_CONTROL` or `CURLUSESSL_ALL` withlibcurl). This requirement could be bypassed if the server would return a properly crafted but perfectly legitimate response.This flaw would then make curl silently continue its operations **withoutTLS** contrary to the instructions and expectations, exposing possibly sensitive data in clear text over the network.",
+            "name": "CVE-2021-22946",
             "scraped_data": [
                 {
+                    "notes": [
+                        "introduced by:\nhttps://github.com/curl/curl/commit/ec3bb8f727405 and\nhttps://github.com/curl/curl/commit/c5ba0c2f544653"
+                    ],
                     "status_table": {
                         "packages": [
                             "curl",
@@ -501,42 +614,41 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (7.74.0-1.3ubuntu2)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (7.68.0-1ubuntu2.7)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (7.58.0-2ubuntu3.15)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (7.47.0-1ubuntu2.19+esm1)"
+                                "focal",
+                                "Released (7.68.0-1ubuntu2.7)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Released (7.74.0-1ubuntu2.3)"
+                            ],
+                            [
+                                "impish",
+                                "Released (7.74.0-1.3ubuntu2)"
+                            ],
+                            [
+                                "trusty",
                                 "Released (7.35.0-1ubuntu2.20+esm8)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (7.47.0-1ubuntu2.19+esm1)"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "introduced by:\nhttps://github.com/curl/curl/commit/ec3bb8f727405 and\nhttps://github.com/curl/curl/commit/c5ba0c2f544653"
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-22946"
         },
         {
-            "name": "CVE-2021-22947",
-            "description": "When curl >= 7.20.0 and <= 7.78.0 connects to an IMAP or POP3 server to retrieve data using STARTTLS to upgrade to TLS security, the server can respond and send back multiple responses at once that curl caches. curl would then upgrade to TLS but not flush the in-queue of cached responses but instead continue using and trustingthe responses it got *before* the TLS handshake as if they were authenticated.Using this flaw, it allows a Man-In-The-Middle attacker to first inject the fake responses, then pass-through the TLS traffic from the legitimate server and trick curl into sending data back to the user thinking the attacker's injected data comes from the TLS-protected server.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-22947",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -555,8 +667,13 @@
                     "value": "4.3"
                 }
             ],
+            "description": "When curl >= 7.20.0 and <= 7.78.0 connects to an IMAP or POP3 server to retrieve data using STARTTLS to upgrade to TLS security, the server can respond and send back multiple responses at once that curl caches. curl would then upgrade to TLS but not flush the in-queue of cached responses but instead continue using and trustingthe responses it got *before* the TLS handshake as if they were authenticated.Using this flaw, it allows a Man-In-The-Middle attacker to first inject the fake responses, then pass-through the TLS traffic from the legitimate server and trick curl into sending data back to the user thinking the attacker's injected data comes from the TLS-protected server.",
+            "name": "CVE-2021-22947",
             "scraped_data": [
                 {
+                    "notes": [
+                        "Originally introduced via https://github.com/curl/curl/commit/ec3bb8f727405 - affects versions between and including 7.20.0 and 7.78.0 - patch in Message-ID: <nycvar.QRO.7.76.2109100828320.2614@fvyyl>"
+                    ],
                     "status_table": {
                         "packages": [
                             "curl",
@@ -566,44 +683,108 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (7.74.0-1.3ubuntu2)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (7.68.0-1ubuntu2.7)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (7.58.0-2ubuntu3.15)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (7.47.0-1ubuntu2.19+esm1)"
+                                "focal",
+                                "Released (7.68.0-1ubuntu2.7)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Released (7.74.0-1ubuntu2.3)"
+                            ],
+                            [
+                                "impish",
+                                "Released (7.74.0-1.3ubuntu2)"
+                            ],
+                            [
+                                "trusty",
                                 "Released (7.35.0-1ubuntu2.20+esm8)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (7.47.0-1ubuntu2.19+esm1)"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "Originally introduced via https://github.com/curl/curl/commit/ec3bb8f727405 - affects versions between and including 7.20.0 and 7.78.0 - patch in Message-ID: <nycvar.QRO.7.76.2109100828320.2614@fvyyl>"
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-22947"
+        }
+    ],
+    "cyrus-sasl2": [
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.1.26.dfsg1-14ubuntu0.2"
+                },
+                {
+                    "key": "package_name",
+                    "value": "cyrus-sasl2"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:S/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.5"
+                }
+            ],
+            "description": "In Cyrus SASL 2.1.17 through 2.1.27 before 2.1.28, plugins/sql.c does not escape the password for a SQL INSERT or UPDATE statement.",
+            "name": "CVE-2022-24407",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "cyrus-sasl2",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.1.27~101-g0780600+dfsg-3ubuntu2.4)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.1.27+dfsg-2ubuntu0.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.1.27+dfsg-2.1ubuntu0.1)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (2.1.25.dfsg1-17ubuntu0.1~esm2)"
+                            ],
+                            [
+                                "upstream",
+                                "Released (2.1.28)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.1.26.dfsg1-14ubuntu0.2+esm1)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "HIGH",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-24407"
         }
     ],
     "expat": [
         {
-            "name": "CVE-2022-23852",
-            "description": "Expat (aka libexpat) before 2.4.4 has a signed integer overflow in XML_GetBuffer, for configurations with a nonzero XML_CONTEXT_BYTES.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-23852",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -615,15 +796,20 @@
                 },
                 {
                     "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                 },
                 {
                     "key": "CVSS2_SCORE",
-                    "value": "7.5"
+                    "value": "6.8"
                 }
             ],
+            "description": "In doProlog in xmlparse.c in Expat (aka libexpat) before 2.4.3, an integer overflow exists for m_groupSize.",
+            "name": "CVE-2021-46143",
             "scraped_data": [
                 {
+                    "notes": [
+                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
+                    ],
                     "status_table": {
                         "packages": [
                             "expat",
@@ -633,42 +819,41 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
+                                "bionic",
+                                "Released (2.2.5-3ubuntu0.4)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.2.9-1ubuntu0.2)"
+                            ],
+                            [
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.1-2ubuntu0.1)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (2.1.0-4ubuntu1.4+esm4)"
+                            ],
+                            [
+                                "upstream",
                                 "Needs triage"
                             ],
                             [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
+                                "xenial",
+                                "Released (2.1.0-7ubuntu0.16.04.5+esm2)"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-46143"
         },
         {
-            "name": "CVE-2022-23990",
-            "description": "Expat (aka libexpat) before 2.4.4 has an integer overflow in the doProlog function.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-23990",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -687,8 +872,13 @@
                     "value": "7.5"
                 }
             ],
+            "description": "addBinding in xmlparse.c in Expat (aka libexpat) before 2.4.3 has an integer overflow.",
+            "name": "CVE-2022-22822",
             "scraped_data": [
                 {
+                    "notes": [
+                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
+                    ],
                     "status_table": {
                         "packages": [
                             "expat",
@@ -698,44 +888,778 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
+                                "bionic",
+                                "Released (2.2.5-3ubuntu0.4)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.2.9-1ubuntu0.2)"
+                            ],
+                            [
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.1-2ubuntu0.1)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (2.1.0-4ubuntu1.4+esm4)"
+                            ],
+                            [
+                                "upstream",
                                 "Needs triage"
                             ],
                             [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
+                                "xenial",
+                                "Released (2.1.0-7ubuntu0.16.04.5+esm2)"
                             ]
                         ]
-                    },
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-22822"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.1.0-7ubuntu0.16.04.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "expat"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "description": "build_model in xmlparse.c in Expat (aka libexpat) before 2.4.3 has an integer overflow.",
+            "name": "CVE-2022-22823",
+            "scraped_data": [
+                {
                     "notes": [
                         "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
-                    ]
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "expat",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.2.5-3ubuntu0.4)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.2.9-1ubuntu0.2)"
+                            ],
+                            [
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.1-2ubuntu0.1)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (2.1.0-4ubuntu1.4+esm4)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.1.0-7ubuntu0.16.04.5+esm2)"
+                            ]
+                        ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-22823"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.1.0-7ubuntu0.16.04.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "expat"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "description": "defineAttribute in xmlparse.c in Expat (aka libexpat) before 2.4.3 has an integer overflow.",
+            "name": "CVE-2022-22824",
+            "scraped_data": [
+                {
+                    "notes": [
+                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "expat",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.2.5-3ubuntu0.4)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.2.9-1ubuntu0.2)"
+                            ],
+                            [
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.1-2ubuntu0.1)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (2.1.0-4ubuntu1.4+esm4)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.1.0-7ubuntu0.16.04.5+esm2)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-22824"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.1.0-7ubuntu0.16.04.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "expat"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.8"
+                }
+            ],
+            "description": "lookup in xmlparse.c in Expat (aka libexpat) before 2.4.3 has an integer overflow.",
+            "name": "CVE-2022-22825",
+            "scraped_data": [
+                {
+                    "notes": [
+                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "expat",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.2.5-3ubuntu0.4)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.2.9-1ubuntu0.2)"
+                            ],
+                            [
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.1-2ubuntu0.1)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (2.1.0-4ubuntu1.4+esm4)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.1.0-7ubuntu0.16.04.5+esm2)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-22825"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.1.0-7ubuntu0.16.04.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "expat"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.8"
+                }
+            ],
+            "description": "nextScaffoldPart in xmlparse.c in Expat (aka libexpat) before 2.4.3 has an integer overflow.",
+            "name": "CVE-2022-22826",
+            "scraped_data": [
+                {
+                    "notes": [
+                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "expat",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.2.5-3ubuntu0.4)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.2.9-1ubuntu0.2)"
+                            ],
+                            [
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.1-2ubuntu0.1)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (2.1.0-4ubuntu1.4+esm4)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.1.0-7ubuntu0.16.04.5+esm2)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-22826"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.1.0-7ubuntu0.16.04.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "expat"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.8"
+                }
+            ],
+            "description": "storeAtts in xmlparse.c in Expat (aka libexpat) before 2.4.3 has an integer overflow.",
+            "name": "CVE-2022-22827",
+            "scraped_data": [
+                {
+                    "notes": [
+                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "expat",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.2.5-3ubuntu0.4)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.2.9-1ubuntu0.2)"
+                            ],
+                            [
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.1-2ubuntu0.1)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (2.1.0-4ubuntu1.4+esm4)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.1.0-7ubuntu0.16.04.5+esm2)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-22827"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.1.0-7ubuntu0.16.04.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "expat"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "description": "Expat (aka libexpat) before 2.4.4 has a signed integer overflow in XML_GetBuffer, for configurations with a nonzero XML_CONTEXT_BYTES.",
+            "name": "CVE-2022-23852",
+            "scraped_data": [
+                {
+                    "notes": [
+                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "expat",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.2.5-3ubuntu0.4)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.2.9-1ubuntu0.2)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.1-2ubuntu0.1)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (2.1.0-4ubuntu1.4+esm4)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.1.0-7ubuntu0.16.04.5+esm2)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-23852"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.1.0-7ubuntu0.16.04.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "expat"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "description": "Expat (aka libexpat) before 2.4.4 has an integer overflow in the doProlog function.",
+            "name": "CVE-2022-23990",
+            "scraped_data": [
+                {
+                    "notes": [
+                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "expat",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.2.5-3ubuntu0.4)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.2.9-1ubuntu0.2)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.1-2ubuntu0.1)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (2.1.0-4ubuntu1.4+esm4)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.1.0-7ubuntu0.16.04.5+esm2)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-23990"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.1.0-7ubuntu0.16.04.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "expat"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "description": "xmltok_impl.c in Expat (aka libexpat) before 2.4.5 lacks certain validation of encoding, such as checks for whether a UTF-8 character is valid in a certain context.",
+            "name": "CVE-2022-25235",
+            "scraped_data": [
+                {
+                    "notes": [
+                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "expat",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.2.5-3ubuntu0.4)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.2.9-1ubuntu0.2)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.1-2ubuntu0.1)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (2.1.0-4ubuntu1.4+esm4)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.1.0-7ubuntu0.16.04.5+esm2)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "HIGH",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-25235"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.1.0-7ubuntu0.16.04.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "expat"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "description": "xmlparse.c in Expat (aka libexpat) before 2.4.5 allows attackers to insert namespace-separator characters into namespace URIs.",
+            "name": "CVE-2022-25236",
+            "scraped_data": [
+                {
+                    "notes": [
+                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "expat",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.2.5-3ubuntu0.4)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.2.9-1ubuntu0.2)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.1-2ubuntu0.1)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (2.1.0-4ubuntu1.4+esm4)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.1.0-7ubuntu0.16.04.5+esm2)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "HIGH",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-25236"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.1.0-7ubuntu0.16.04.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "expat"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "4.3"
+                }
+            ],
+            "description": "In Expat (aka libexpat) before 2.4.5, an attacker can trigger stack exhaustion in build_model via a large nesting depth in the DTD element.",
+            "name": "CVE-2022-25313",
+            "scraped_data": [
+                {
+                    "notes": [
+                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "expat",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.2.5-3ubuntu0.7)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.2.9-1ubuntu0.4)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.1-2ubuntu0.3)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (2.1.0-4ubuntu1.4+esm6)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.1.0-7ubuntu0.16.04.5+esm5)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-25313"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.1.0-7ubuntu0.16.04.5"
+                },
+                {
+                    "key": "package_name",
+                    "value": "expat"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.5"
+                }
+            ],
+            "description": "In Expat (aka libexpat) before 2.4.5, there is an integer overflow in storeRawNames.",
+            "name": "CVE-2022-25315",
+            "scraped_data": [
+                {
+                    "notes": [
+                        "paraview uses system expat\nxotcl uses system expat\npoco uses system expat\ngdcm uses system expat\naudacity uses system expat\nsimgear uses system expat\ncoin3 uses system expat as of 4.0.0~CMake~6f54f1602475+ds1-1\nsitecopy uses system expat since 1:0.16.0-1 (dapper!)"
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "expat",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.2.5-3ubuntu0.7)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.2.9-1ubuntu0.4)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.1-2ubuntu0.3)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (2.1.0-4ubuntu1.4+esm6)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.1.0-7ubuntu0.16.04.5+esm5)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-25315"
         }
     ],
     "gcc-5": [
         {
-            "name": "CVE-2020-13844",
-            "description": "Arm Armv8-A core implementations utilizing speculative execution past unconditional changes in control flow may allow unauthorized disclosure of information to an attacker with local user access via a side-channel analysis, aka \"straight-line speculation.\"",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-13844",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -754,8 +1678,13 @@
                     "value": "2.1"
                 }
             ],
+            "description": "Arm Armv8-A core implementations utilizing speculative execution past unconditional changes in control flow may allow unauthorized disclosure of information to an attacker with local user access via a side-channel analysis, aka \"straight-line speculation.\"",
+            "name": "CVE-2020-13844",
             "scraped_data": [
                 {
+                    "notes": [
+                        "gcc-3.3 only provides libstdc++5"
+                    ],
                     "status_table": {
                         "packages": [
                             "gcc-5",
@@ -765,44 +1694,55 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
+                                "upstream",
                                 "Needs triage"
                             ],
                             [
-                                "Ubuntu 21.10 (Impish Indri)",
+                                "precise",
                                 "Does not exist"
                             ],
                             [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "trusty",
                                 "Does not exist"
                             ],
                             [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Deferred"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Deferred"
+                                "eoan",
+                                "Does not exist"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "focal",
                                 "Does not exist"
+                            ],
+                            [
+                                "impish",
+                                "Does not exist"
+                            ],
+                            [
+                                "groovy",
+                                "Does not exist"
+                            ],
+                            [
+                                "hirsute",
+                                "Does not exist"
+                            ],
+                            [
+                                "xenial",
+                                "Deferred"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "gcc-3.3 only provides libstdc++5"
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-13844"
         }
     ],
     "gcc-defaults": [
         {
-            "name": "CVE-2020-13844",
-            "description": "Arm Armv8-A core implementations utilizing speculative execution past unconditional changes in control flow may allow unauthorized disclosure of information to an attacker with local user access via a side-channel analysis, aka \"straight-line speculation.\"",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-13844",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -821,8 +1761,13 @@
                     "value": "2.1"
                 }
             ],
+            "description": "Arm Armv8-A core implementations utilizing speculative execution past unconditional changes in control flow may allow unauthorized disclosure of information to an attacker with local user access via a side-channel analysis, aka \"straight-line speculation.\"",
+            "name": "CVE-2020-13844",
             "scraped_data": [
                 {
+                    "notes": [
+                        "gcc-3.3 only provides libstdc++5"
+                    ],
                     "status_table": {
                         "packages": [
                             "gcc-defaults",
@@ -832,44 +1777,55 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
+                                "groovy",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "upstream",
                                 "Needs triage"
                             ],
                             [
-                                "Ubuntu 21.10 (Impish Indri)",
+                                "precise",
+                                "Ignored (end of ESM support, was deferred)"
+                            ],
+                            [
+                                "trusty",
                                 "Deferred"
                             ],
                             [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "bionic",
                                 "Deferred"
                             ],
                             [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "eoan",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "focal",
                                 "Deferred"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "impish",
                                 "Deferred"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "xenial",
                                 "Deferred"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "gcc-3.3 only provides libstdc++5"
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-13844"
         }
     ],
     "gccgo-6": [
         {
-            "name": "CVE-2020-13844",
-            "description": "Arm Armv8-A core implementations utilizing speculative execution past unconditional changes in control flow may allow unauthorized disclosure of information to an attacker with local user access via a side-channel analysis, aka \"straight-line speculation.\"",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-13844",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -888,8 +1844,13 @@
                     "value": "2.1"
                 }
             ],
+            "description": "Arm Armv8-A core implementations utilizing speculative execution past unconditional changes in control flow may allow unauthorized disclosure of information to an attacker with local user access via a side-channel analysis, aka \"straight-line speculation.\"",
+            "name": "CVE-2020-13844",
             "scraped_data": [
                 {
+                    "notes": [
+                        "gcc-3.3 only provides libstdc++5"
+                    ],
                     "status_table": {
                         "packages": [
                             "gccgo-6",
@@ -899,44 +1860,126 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
+                                "upstream",
                                 "Needs triage"
                             ],
                             [
-                                "Ubuntu 21.10 (Impish Indri)",
+                                "precise",
                                 "Does not exist"
                             ],
                             [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "trusty",
                                 "Does not exist"
                             ],
                             [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Does not exist"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "eoan",
+                                "Does not exist"
+                            ],
+                            [
+                                "focal",
+                                "Does not exist"
+                            ],
+                            [
+                                "impish",
+                                "Does not exist"
+                            ],
+                            [
+                                "groovy",
+                                "Does not exist"
+                            ],
+                            [
+                                "hirsute",
+                                "Does not exist"
+                            ],
+                            [
+                                "xenial",
                                 "Deferred"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Does not exist"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "gcc-3.3 only provides libstdc++5"
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-13844"
+        }
+    ],
+    "gdk-pixbuf": [
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.32.2-1ubuntu1.6"
+                },
+                {
+                    "key": "package_name",
+                    "value": "gdk-pixbuf"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.8"
+                }
+            ],
+            "description": "GNOME gdk-pixbuf 2.42.6 is vulnerable to a heap-buffer overflow vulnerability when decoding the lzw compressed stream of image data in GIF files with lzw minimum code size equals to 12.",
+            "name": "CVE-2021-44648",
+            "scraped_data": [
+                {
+                    "notes": [
+                        "as of 2022-04-19, proposed fix not commited upstream"
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "gdk-pixbuf",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Deferred (2022-04-19)"
+                            ],
+                            [
+                                "focal",
+                                "Deferred (2022-04-19)"
+                            ],
+                            [
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
+                                "Deferred (2022-04-19)"
+                            ],
+                            [
+                                "trusty",
+                                "Ignored (out of standard support)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Deferred (2022-04-19)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-44648"
         }
     ],
     "git": [
         {
-            "name": "CVE-2021-40330",
-            "description": "git_connect_git in connect.c in Git before 2.30.1 allows a repository path to contain a newline character, which may result in unexpected cross-protocol requests, as demonstrated by the git://localhost:1234/%0d%0a%0d%0aGET%20/%20HTTP/1.1 substring.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-40330",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -955,8 +1998,11 @@
                     "value": "5"
                 }
             ],
+            "description": "git_connect_git in connect.c in Git before 2.30.1 allows a repository path to contain a newline character, which may result in unexpected cross-protocol requests, as demonstrated by the git://localhost:1234/%0d%0a%0d%0aGET%20/%20HTTP/1.1 substring.",
+            "name": "CVE-2021-40330",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "git",
@@ -966,46 +2012,43 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (1:2.30.1-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (1:2.25.1-1ubuntu3.2)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (1:2.17.1-1ubuntu0.9)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (1:2.7.4-0ubuntu1.10+esm1)"
+                                "focal",
+                                "Released (1:2.25.1-1ubuntu3.2)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Not vulnerable (1:2.30.2-1ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Not vulnerable"
+                            ],
+                            [
+                                "trusty",
                                 "Does not exist"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Released (1:2.30.1-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (1:2.7.4-0ubuntu1.10+esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-40330"
         }
     ],
     "glib2.0": [
         {
-            "name": "CVE-2021-3800",
-            "description": "glib2: Possible privilege escalation thourgh pkexec and aliases",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3800",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -1016,8 +2059,11 @@
                     "value": "glib2.0"
                 }
             ],
+            "description": "glib2: Possible privilege escalation thourgh pkexec and aliases",
+            "name": "CVE-2021-3800",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "glib2.0",
@@ -1027,46 +2073,43 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (2.62.5)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable (2.68.4-1ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Not vulnerable (2.64.6-1~ubuntu20.04.4)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (2.56.4-0ubuntu0.18.04.9)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.48.2-0ubuntu4.8+esm1)"
+                                "focal",
+                                "Not vulnerable (2.64.6-1~ubuntu20.04.4)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Not vulnerable (2.68.1-1~ubuntu21.04.1)"
+                            ],
+                            [
+                                "impish",
+                                "Not vulnerable (2.68.4-1ubuntu1)"
+                            ],
+                            [
+                                "trusty",
                                 "Released (2.40.2-0ubuntu1.1+esm4)"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Released (2.62.5)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.48.2-0ubuntu4.8+esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3800"
         }
     ],
     "glibc": [
         {
-            "name": "CVE-2021-38604",
-            "description": "In librt in the GNU C Library (aka glibc) through 2.34, sysdeps/unix/sysv/linux/mq_notify.c mishandles certain NOTIFY_REMOVED data, leading to a NULL pointer dereference. NOTE: this vulnerability was introduced as a side effect of the CVE-2021-33574 fix.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-38604",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -1075,18 +2118,13 @@
                 {
                     "key": "package_name",
                     "value": "glibc"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "5"
                 }
             ],
+            "description": "Off-by-one buffer overflow/underflow in glibc's getcwd()",
+            "name": "CVE-2021-3999",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "glibc",
@@ -1096,46 +2134,37 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Pending (2.35)"
+                                "bionic",
+                                "Released (2.27-3ubuntu1.5)"
                             ],
                             [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable (2.34-0ubuntu3)"
+                                "focal",
+                                "Released (2.31-0ubuntu9.7)"
                             ],
                             [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Needed"
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
                             ],
                             [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Needed"
+                                "impish",
+                                "Released (2.34-0ubuntu3.2)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Needed"
+                                "upstream",
+                                "Needs triage"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Does not exist"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream: Upstream:"
+                                "xenial",
+                                "Released (2.23-0ubuntu11.3+esm1)"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "21.04 and earlier are not affected due to the fix for\nCVE-2021-33574 having not been introduced yet."
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3999"
         },
         {
-            "name": "CVE-2021-38604",
-            "description": "In librt in the GNU C Library (aka glibc) through 2.34, sysdeps/unix/sysv/linux/mq_notify.c mishandles certain NOTIFY_REMOVED data, leading to a NULL pointer dereference. NOTE: this vulnerability was introduced as a side effect of the CVE-2021-33574 fix.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-38604",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -1144,18 +2173,13 @@
                 {
                     "key": "package_name",
                     "value": "glibc"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "5"
                 }
             ],
+            "description": "Off-by-one buffer overflow/underflow in glibc's getcwd()",
+            "name": "CVE-2021-3999",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "glibc",
@@ -1165,48 +2189,96 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Pending (2.35)"
+                                "bionic",
+                                "Released (2.27-3ubuntu1.5)"
                             ],
                             [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable (2.34-0ubuntu3)"
+                                "focal",
+                                "Released (2.31-0ubuntu9.7)"
                             ],
                             [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Needed"
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
                             ],
                             [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Needed"
+                                "impish",
+                                "Released (2.34-0ubuntu3.2)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Needed"
+                                "upstream",
+                                "Needs triage"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Does not exist"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream: Upstream:"
+                                "xenial",
+                                "Released (2.23-0ubuntu11.3+esm1)"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "21.04 and earlier are not affected due to the fix for\nCVE-2021-33574 having not been introduced yet."
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3999"
+        }
+    ],
+    "gzip": [
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "1.6-4ubuntu1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "gzip"
+                }
+            ],
+            "description": "arbitrary file overwrite with crafted file names",
+            "name": "CVE-2022-1271",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "gzip",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (1.6-5ubuntu1.2)"
+                            ],
+                            [
+                                "focal",
+                                "Released (1.10-0ubuntu4.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (1.10-4ubuntu1.1)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (1.6-3ubuntu1+esm1)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (1.6-4ubuntu1+esm1)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-1271"
         }
     ],
     "imagemagick": [
         {
-            "name": "CVE-2020-25664",
-            "description": "In WriteOnePNGImage() of the PNG coder at coders/png.c, an improper call to AcquireVirtualMemory() and memset() allows for an out-of-bounds write later when PopShortPixel() from MagickCore/quantum-private.h is called. The patch fixes the calls by adding 256 to rowbytes. An attacker who is able to supply a specially crafted image could affect availability with a low impact to data integrity. This flaw affects ImageMagick versions prior to 6.9.10-68 and 7.0.8-68.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-25664",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -1225,8 +2297,13 @@
                     "value": "5.8"
                 }
             ],
+            "description": "In WriteOnePNGImage() of the PNG coder at coders/png.c, an improper call to AcquireVirtualMemory() and memset() allows for an out-of-bounds write later when PopShortPixel() from MagickCore/quantum-private.h is called. The patch fixes the calls by adding 256 to rowbytes. An attacker who is able to supply a specially crafted image could affect availability with a low impact to data integrity. This flaw affects ImageMagick versions prior to 6.9.10-68 and 7.0.8-68.",
+            "name": "CVE-2020-25664",
             "scraped_data": [
                 {
+                    "notes": [
+                        "fix attempt was reverted\nunclear what the fix for this issue is as of 2021-06-10"
+                    ],
                     "status_table": {
                         "packages": [
                             "imagemagick",
@@ -1236,46 +2313,49 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (8:6.9.11.24+dfsg-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
+                                "bionic",
                                 "Deferred"
                             ],
                             [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "focal",
                                 "Deferred"
                             ],
                             [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "groovy",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
                                 "Deferred"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Deferred"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "precise",
                                 "Does not exist"
                             ],
                             [
-                                "Patches:",
-                                "Upstream: Upstream:"
+                                "trusty",
+                                "Does not exist"
+                            ],
+                            [
+                                "upstream",
+                                "Released (8:6.9.11.24+dfsg-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (8:6.8.9.9-7ubuntu5.16+esm2)"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "fix attempt was reverted\nunclear what the fix for this issue is as of 2021-06-10"
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-25664"
         },
         {
-            "name": "CVE-2020-27752",
-            "description": "A flaw was found in ImageMagick in MagickCore/quantum-private.h. An attacker who submits a crafted file that is processed by ImageMagick could trigger a heap buffer overflow. This would most likely lead to an impact to application availability, but could potentially lead to an impact to data integrity as well. This flaw affects ImageMagick versions prior to 7.0.9-0.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-27752",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -1294,8 +2374,13 @@
                     "value": "5.8"
                 }
             ],
+            "description": "A flaw was found in ImageMagick in MagickCore/quantum-private.h. An attacker who submits a crafted file that is processed by ImageMagick could trigger a heap buffer overflow. This would most likely lead to an impact to application availability, but could potentially lead to an impact to data integrity as well. This flaw affects ImageMagick versions prior to 7.0.9-0.",
+            "name": "CVE-2020-27752",
             "scraped_data": [
                 {
+                    "notes": [
+                        "need to clarify exact patch, see Debian comment on upstream bug"
+                    ],
                     "status_table": {
                         "packages": [
                             "imagemagick",
@@ -1305,44 +2390,51 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (8:6.9.11.24+dfsg-1)"
+                                "bionic",
+                                "Deferred"
                             ],
                             [
-                                "Ubuntu 21.10 (Impish Indri)",
+                                "focal",
+                                "Deferred"
+                            ],
+                            [
+                                "groovy",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "hirsute",
                                 "Not vulnerable (8:6.9.11.60+dfsg-1ubuntu1)"
                             ],
                             [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Deferred"
+                                "impish",
+                                "Not vulnerable (8:6.9.11.60+dfsg-1ubuntu1)"
                             ],
                             [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Deferred"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Deferred"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "precise",
                                 "Does not exist"
+                            ],
+                            [
+                                "trusty",
+                                "Does not exist"
+                            ],
+                            [
+                                "upstream",
+                                "Released (8:6.9.11.24+dfsg-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Deferred"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "need to clarify exact patch, see Debian comment on upstream bug"
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-27752"
         }
     ],
     "krb5": [
         {
-            "name": "CVE-2018-20217",
-            "description": "A Reachable Assertion issue was discovered in the KDC in MIT Kerberos 5 (aka krb5) before 1.17. If an attacker can obtain a krbtgt ticket using an older encryption type (single-DES, triple-DES, or RC4), the attacker can crash the KDC by making an S4U2Self request.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20217",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -1361,8 +2453,11 @@
                     "value": "3.5"
                 }
             ],
+            "description": "A Reachable Assertion issue was discovered in the KDC in MIT Kerberos 5 (aka krb5) before 1.17. If an attacker can obtain a krbtgt ticket using an older encryption type (single-DES, triple-DES, or RC4), the attacker can crash the KDC by making an S4U2Self request.",
+            "name": "CVE-2018-20217",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "krb5",
@@ -1372,50 +2467,63 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (1.17)"
+                                "bionic",
+                                "Needed"
                             ],
                             [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable (1.17-10)"
+                                "cosmic",
+                                "Ignored (reached end-of-life)"
                             ],
                             [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "disco",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "eoan",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "focal",
                                 "Not vulnerable (1.17-6ubuntu4)"
                             ],
                             [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "groovy",
+                                "Not vulnerable (1.17-10)"
+                            ],
+                            [
+                                "hirsute",
+                                "Not vulnerable (1.17-10)"
+                            ],
+                            [
+                                "impish",
+                                "Not vulnerable (1.17-10)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needs-triage)"
+                            ],
+                            [
+                                "trusty",
                                 "Needed"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "upstream",
+                                "Released (1.17)"
+                            ],
+                            [
+                                "xenial",
                                 "Needed"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ],
-                            [
-                                "Binaries built from this source package are in",
-                                "and so are supported by the community."
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20217"
         }
     ],
     "libgcrypt20": [
         {
-            "name": "CVE-2021-40528",
-            "description": "The ElGamal implementation in Libgcrypt before 1.9.4 allows plaintext recovery because, during interaction between two cryptographic libraries, a certain dangerous combination of the prime defined by the receiver's public key, the generator defined by the receiver's public key, and the sender's ephemeral exponents can lead to a cross-configuration attack against OpenPGP.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-40528",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -1434,8 +2542,13 @@
                     "value": "2.6"
                 }
             ],
+            "description": "The ElGamal implementation in Libgcrypt before 1.9.4 allows plaintext recovery because, during interaction between two cryptographic libraries, a certain dangerous combination of the prime defined by the receiver's public key, the generator defined by the receiver's public key, and the sender's ephemeral exponents can lead to a cross-configuration attack against OpenPGP.",
+            "name": "CVE-2021-40528",
             "scraped_data": [
                 {
+                    "notes": [
+                        "The commits below reference CVE-2021-33560, but they appear to\nactually be for this CVE, which was issued later. The original\nCVE was switched later on to the exponent blinding issue\ninstead."
+                    ],
                     "status_table": {
                         "packages": [
                             "libgcrypt20",
@@ -1445,48 +2558,43 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (1.9.4-2)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (1.8.7-5ubuntu2)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (1.8.5-5ubuntu1.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (1.8.1-4ubuntu1.3)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (1.6.5-2ubuntu0.6+esm1)"
+                                "focal",
+                                "Released (1.8.5-5ubuntu1.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Released (1.8.7-2ubuntu2.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (1.8.7-5ubuntu2)"
+                            ],
+                            [
+                                "trusty",
                                 "Does not exist"
                             ],
                             [
-                                "Patches:",
-                                "Upstream: Upstream:"
+                                "upstream",
+                                "Released (1.9.4-2)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (1.6.5-2ubuntu0.6+esm1)"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "The commits below reference CVE-2021-33560, but they appear to\nactually be for this CVE, which was issued later. The original\nCVE was switched later on to the exponent blinding issue\ninstead."
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-40528"
         }
     ],
     "libgd2": [
         {
-            "name": "CVE-2021-40145",
-            "description": "** DISPUTED ** gdImageGd2Ptr in gd_gd2.c in the GD Graphics Library (aka LibGD) through 2.3.2 has a double free. NOTE: the vendor's position is \"The GD2 image format is a proprietary image format of libgd. It has to be regarded as being obsolete, and should only be used for development and testing purposes.\"",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-40145",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -1505,8 +2613,13 @@
                     "value": "5"
                 }
             ],
+            "description": "** DISPUTED ** gdImageGd2Ptr in gd_gd2.c in the GD Graphics Library (aka LibGD) through 2.3.2 has a double free. NOTE: the vendor's position is \"The GD2 image format is a proprietary image format of libgd. It has to be regarded as being obsolete, and should only be used for development and testing purposes.\"",
+            "name": "CVE-2021-40145",
             "scraped_data": [
                 {
+                    "notes": [
+                        "php uses the system libgd2"
+                    ],
                     "status_table": {
                         "packages": [
                             "libgd2",
@@ -1516,44 +2629,43 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2.3.0-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.2.5-5.2ubuntu2.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (2.2.5-4ubuntu0.5)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.1.1-4ubuntu0.16.04.12+esm1)"
+                                "focal",
+                                "Released (2.2.5-5.2ubuntu2.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Released (2.3.0-2ubuntu0.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.3.0-2ubuntu1)"
+                            ],
+                            [
+                                "trusty",
                                 "Released (2.1.0-3ubuntu0.11+esm2)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.1.1-4ubuntu0.16.04.12+esm1)"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "php uses the system libgd2"
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-40145"
         }
     ],
     "libsndfile": [
         {
-            "name": "CVE-2021-3246",
-            "description": "A heap buffer overflow vulnerability in msadpcm_decode_block of libsndfile 1.0.30 allows attackers to execute arbitrary code via a crafted WAV file.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3246",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -1572,8 +2684,11 @@
                     "value": "6.8"
                 }
             ],
+            "description": "A heap buffer overflow vulnerability in msadpcm_decode_block of libsndfile 1.0.30 allows attackers to execute arbitrary code via a crafted WAV file.",
+            "name": "CVE-2021-3246",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "libsndfile",
@@ -1583,46 +2698,122 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (1.0.31-1ubuntu2)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (1.0.28-7ubuntu0.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (1.0.28-4ubuntu0.18.04.2)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (1.0.25-10ubuntu0.16.04.3+esm1)"
+                                "focal",
+                                "Released (1.0.28-7ubuntu0.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (1.0.31-1ubuntu1.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (1.0.31-1ubuntu2)"
+                            ],
+                            [
+                                "trusty",
                                 "Released (1.0.25-7ubuntu2.2+esm2)"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (1.0.25-10ubuntu0.16.04.3+esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3246"
         }
     ],
     "libwebp": [
         {
-            "name": "CVE-2018-25009",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.4.4-1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libwebp"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.4"
+                }
+            ],
             "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function WebPMuxCreateInternal. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25009",
+            "name": "CVE-2018-25009",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "focal",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "groovy",
+                                "Released (0.6.1-2ubuntu0.20.10.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (0.6.1-2ubuntu0.21.04.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25009"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -1641,75 +2832,11 @@
                     "value": "6.4"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "libwebp",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (0.6.1-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (0.6.1-2ubuntu0.20.04.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (0.6.1-2ubuntu0.18.04.1)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (0.4.4-1ubuntu0.1~esm1)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Released (0.4.0-4ubuntu0.1~esm1)"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2018-25010",
             "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function ApplyFilter. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25010",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "0.4.4-1"
-                },
-                {
-                    "key": "package_name",
-                    "value": "libwebp"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "6.4"
-                }
-            ],
+            "name": "CVE-2018-25010",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "libwebp",
@@ -1719,44 +2846,49 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (0.6.1-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (0.6.1-2ubuntu0.20.04.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (0.6.1-2ubuntu0.18.04.1)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                                "focal",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (0.6.1-2ubuntu0.20.10.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (0.6.1-2ubuntu0.21.04.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
                                 "Released (0.4.0-4ubuntu0.1~esm1)"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25010"
         },
         {
-            "name": "CVE-2018-25011",
-            "description": "A flaw was found in libwebp in versions before 1.0.1. A heap-based buffer overflow was found in PutLE16(). The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25011",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -1775,8 +2907,11 @@
                     "value": "7.5"
                 }
             ],
+            "description": "A flaw was found in libwebp in versions before 1.0.1. A heap-based buffer overflow was found in PutLE16(). The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
+            "name": "CVE-2018-25011",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "libwebp",
@@ -1786,44 +2921,49 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (0.6.1-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (0.6.1-2ubuntu0.20.04.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (0.6.1-2ubuntu0.18.04.1)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                                "focal",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (0.6.1-2ubuntu0.20.10.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (0.6.1-2ubuntu0.21.04.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
                                 "Released (0.4.0-4ubuntu0.1~esm1)"
                             ],
                             [
-                                "Patches:",
-                                "Upstream: Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25011"
         },
         {
-            "name": "CVE-2018-25012",
-            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function WebPMuxCreateInternal. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25012",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -1842,57 +2982,140 @@
                     "value": "6.4"
                 }
             ],
+            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function WebPMuxCreateInternal. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
+            "name": "CVE-2018-25012",
             "scraped_data": [
                 {
-                    "status_table": {
-                        "packages": [
-                            "libwebp",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (0.6.1-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (0.6.1-2ubuntu0.20.04.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (0.6.1-2ubuntu0.18.04.1)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (0.4.4-1ubuntu0.1~esm1)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Released (0.4.0-4ubuntu0.1~esm1)"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
                     "notes": [
                         "same commit as CVE-2018-25009"
-                    ]
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "focal",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "groovy",
+                                "Released (0.6.1-2ubuntu0.20.10.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (0.6.1-2ubuntu0.21.04.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ]
+                        ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25012"
         },
         {
-            "name": "CVE-2018-25013",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "0.4.4-1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "libwebp"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "6.4"
+                }
+            ],
             "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function ShiftBytes. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25013",
+            "name": "CVE-2018-25013",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "focal",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "groovy",
+                                "Released (0.6.1-2ubuntu0.20.10.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (0.6.1-2ubuntu0.21.04.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25013"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -1904,62 +3127,70 @@
                 },
                 {
                     "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
+                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
                 },
                 {
                     "key": "CVSS2_SCORE",
-                    "value": "6.4"
+                    "value": "7.5"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "libwebp",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (0.6.1-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (0.6.1-2ubuntu0.20.04.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (0.6.1-2ubuntu0.18.04.1)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (0.4.4-1ubuntu0.1~esm1)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Released (0.4.0-4ubuntu0.1~esm1)"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2018-25014",
             "description": "A flaw was found in libwebp in versions before 1.0.1. An unitialized variable is used in function ReadSymbol. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25014",
+            "name": "CVE-2018-25014",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "focal",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "groovy",
+                                "Released (0.6.1-2ubuntu0.20.10.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (0.6.1-2ubuntu0.21.04.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-25014"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -1978,55 +3209,63 @@
                     "value": "7.5"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "libwebp",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (0.6.1-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (0.6.1-2ubuntu0.20.04.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (0.6.1-2ubuntu0.18.04.1)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (0.4.4-1ubuntu0.1~esm1)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Released (0.4.0-4ubuntu0.1~esm1)"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2020-36328",
             "description": "A flaw was found in libwebp in versions before 1.0.1. A heap-based buffer overflow in function WebPDecodeRGBInto is possible due to an invalid check for buffer size. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36328",
+            "name": "CVE-2020-36328",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "focal",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "groovy",
+                                "Released (0.6.1-2ubuntu0.20.10.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (0.6.1-2ubuntu0.21.04.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36328"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -2045,55 +3284,63 @@
                     "value": "7.5"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "libwebp",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (0.6.1-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (0.6.1-2ubuntu0.20.04.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (0.6.1-2ubuntu0.18.04.1)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (0.4.4-1ubuntu0.1~esm1)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Released (0.4.0-4ubuntu0.1~esm1)"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2020-36329",
             "description": "A flaw was found in libwebp in versions before 1.0.1. A use-after-free was found due to a thread being killed too early. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36329",
+            "name": "CVE-2020-36329",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "libwebp",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (0.6.1-2ubuntu0.18.04.1)"
+                            ],
+                            [
+                                "focal",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
+                            ],
+                            [
+                                "groovy",
+                                "Released (0.6.1-2ubuntu0.20.10.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (0.6.1-2ubuntu0.21.04.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
+                                "Released (0.4.0-4ubuntu0.1~esm1)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36329"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -2105,82 +3352,18 @@
                 },
                 {
                     "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
                 },
                 {
                     "key": "CVSS2_SCORE",
-                    "value": "7.5"
+                    "value": "6.4"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "libwebp",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (0.6.1-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (0.6.1-2ubuntu0.20.04.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (0.6.1-2ubuntu0.18.04.1)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (0.4.4-1ubuntu0.1~esm1)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Released (0.4.0-4ubuntu0.1~esm1)"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2020-36330",
             "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function ChunkVerifyAndAssign. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36330",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "0.4.4-1"
-                },
-                {
-                    "key": "package_name",
-                    "value": "libwebp"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "6.4"
-                }
-            ],
+            "name": "CVE-2020-36330",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "libwebp",
@@ -2190,44 +3373,49 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (0.6.1-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (0.6.1-2ubuntu0.20.04.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (0.6.1-2ubuntu0.18.04.1)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                                "focal",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (0.6.1-2ubuntu0.20.10.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (0.6.1-2ubuntu0.21.04.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
                                 "Released (0.4.0-4ubuntu0.1~esm1)"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36330"
         },
         {
-            "name": "CVE-2020-36331",
-            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function ChunkAssignData. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36331",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -2246,8 +3434,11 @@
                     "value": "6.4"
                 }
             ],
+            "description": "A flaw was found in libwebp in versions before 1.0.1. An out-of-bounds read was found in function ChunkAssignData. The highest threat from this vulnerability is to data confidentiality and to the service availability.",
+            "name": "CVE-2020-36331",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "libwebp",
@@ -2257,46 +3448,51 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (0.6.1-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (0.6.1-2ubuntu0.20.04.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (0.6.1-2ubuntu0.18.04.1)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (0.4.4-1ubuntu0.1~esm1)"
+                                "focal",
+                                "Released (0.6.1-2ubuntu0.20.04.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (0.6.1-2ubuntu0.20.10.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (0.6.1-2ubuntu0.21.04.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (0.6.1-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
                                 "Released (0.4.0-4ubuntu0.1~esm1)"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (0.4.4-1ubuntu0.1~esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36331"
         }
     ],
     "libx11": [
         {
-            "name": "CVE-2021-31535",
-            "description": "LookupCol.c in X.Org X through X11R7.7 and libX11 before 1.7.1 might allow remote attackers to execute arbitrary code. The libX11 XLookupColor request (intended for server-side color lookup) contains a flaw allowing a client to send color-name requests with a name longer than the maximum size allowed by the protocol (and also longer than the maximum packet size for normal-sized packets). The user-controlled data exceeding the maximum size is then interpreted by the server as additional X protocol requests and executed, e.g., to disable X server authorization completely. For example, if the victim encounters malicious terminal control sequences for color codes, then the attacker may be able to take full control of the running graphical session.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-31535",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -2315,8 +3511,11 @@
                     "value": "7.5"
                 }
             ],
+            "description": "LookupCol.c in X.Org X through X11R7.7 and libX11 before 1.7.1 might allow remote attackers to execute arbitrary code. The libX11 XLookupColor request (intended for server-side color lookup) contains a flaw allowing a client to send color-name requests with a name longer than the maximum size allowed by the protocol (and also longer than the maximum packet size for normal-sized packets). The user-controlled data exceeding the maximum size is then interpreted by the server as additional X protocol requests and executed, e.g., to disable X server authorization completely. For example, if the victim encounters malicious terminal control sequences for color codes, then the attacker may be able to take full control of the running graphical session.",
+            "name": "CVE-2021-31535",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "libx11",
@@ -2326,46 +3525,51 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (1.7.0-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2:1.6.9-2ubuntu1.2)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (2:1.6.4-3ubuntu0.4)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2:1.6.3-1ubuntu2.2+esm1)"
+                                "focal",
+                                "Released (2:1.6.9-2ubuntu1.2)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (2:1.6.12-1ubuntu0.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2:1.7.0-2ubuntu0.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (1.7.0-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needs-triage)"
+                            ],
+                            [
+                                "trusty",
                                 "Released (2:1.6.2-1ubuntu2.1+esm2)"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2:1.6.3-1ubuntu2.2+esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-31535"
         }
     ],
     "libxml2": [
         {
-            "name": "CVE-2021-3516",
-            "description": "There's a flaw in libxml2's xmllint in versions before 2.9.11. An attacker who is able to submit a crafted file to be processed by xmllint could trigger a use-after-free. The greatest impact of this flaw is to confidentiality, integrity, and availability.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3516",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -2384,8 +3588,11 @@
                     "value": "6.8"
                 }
             ],
+            "description": "There's a flaw in libxml2's xmllint in versions before 2.9.11. An attacker who is able to submit a crafted file to be processed by xmllint could trigger a use-after-free. The greatest impact of this flaw is to confidentiality, integrity, and availability.",
+            "name": "CVE-2021-3516",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "libxml2",
@@ -2395,40 +3602,49 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (2.9.10+dfsg-6.6)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable (2.9.10+dfsg-6.7)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (2.9.4+dfsg1-6.1ubuntu1.4)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
+                                "focal",
+                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (2.9.10+dfsg-5ubuntu0.20.10.2)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.9.10+dfsg-6.3ubuntu0.1)"
+                            ],
+                            [
+                                "impish",
+                                "Not vulnerable (2.9.10+dfsg-6.7)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needs-triage)"
+                            ],
+                            [
+                                "trusty",
                                 "Released (2.9.1+dfsg1-3ubuntu4.13+esm2)"
+                            ],
+                            [
+                                "upstream",
+                                "Released (2.9.10+dfsg-6.6)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3516"
         },
         {
-            "name": "CVE-2021-3517",
-            "description": "There is a flaw in the xml entity encoding functionality of libxml2 in versions before 2.9.11. An attacker who is able to supply a crafted file to be processed by an application linked with the affected functionality of libxml2 could trigger an out-of-bounds read. The most likely impact of this flaw is to application availability, with some potential impact to confidentiality and integrity if an attacker is able to use memory information to further exploit the application.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3517",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -2447,8 +3663,11 @@
                     "value": "7.5"
                 }
             ],
+            "description": "There is a flaw in the xml entity encoding functionality of libxml2 in versions before 2.9.11. An attacker who is able to supply a crafted file to be processed by an application linked with the affected functionality of libxml2 could trigger an out-of-bounds read. The most likely impact of this flaw is to application availability, with some potential impact to confidentiality and integrity if an attacker is able to use memory information to further exploit the application.",
+            "name": "CVE-2021-3517",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "libxml2",
@@ -2458,40 +3677,49 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (2.9.10+dfsg-6.6)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable (2.9.10+dfsg-6.7)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (2.9.4+dfsg1-6.1ubuntu1.4)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
+                                "focal",
+                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (2.9.10+dfsg-5ubuntu0.20.10.2)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.9.10+dfsg-6.3ubuntu0.1)"
+                            ],
+                            [
+                                "impish",
+                                "Not vulnerable (2.9.10+dfsg-6.7)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needs-triage)"
+                            ],
+                            [
+                                "trusty",
                                 "Released (2.9.1+dfsg1-3ubuntu4.13+esm2)"
+                            ],
+                            [
+                                "upstream",
+                                "Released (2.9.10+dfsg-6.6)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3517"
         },
         {
-            "name": "CVE-2021-3518",
-            "description": "There's a flaw in libxml2 in versions before 2.9.11. An attacker who is able to submit a crafted file to be processed by an application linked with libxml2 could trigger a use-after-free. The greatest impact from this flaw is to confidentiality, integrity, and availability.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3518",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -2510,8 +3738,11 @@
                     "value": "6.8"
                 }
             ],
+            "description": "There's a flaw in libxml2 in versions before 2.9.11. An attacker who is able to submit a crafted file to be processed by an application linked with libxml2 could trigger a use-after-free. The greatest impact from this flaw is to confidentiality, integrity, and availability.",
+            "name": "CVE-2021-3518",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "libxml2",
@@ -2521,40 +3752,49 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (2.9.10+dfsg-6.6)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable (2.9.10+dfsg-6.7)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (2.9.4+dfsg1-6.1ubuntu1.4)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
+                                "focal",
+                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (2.9.10+dfsg-5ubuntu0.20.10.2)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.9.10+dfsg-6.3ubuntu0.1)"
+                            ],
+                            [
+                                "impish",
+                                "Not vulnerable (2.9.10+dfsg-6.7)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needs-triage)"
+                            ],
+                            [
+                                "trusty",
                                 "Released (2.9.1+dfsg1-3ubuntu4.13+esm2)"
+                            ],
+                            [
+                                "upstream",
+                                "Released (2.9.10+dfsg-6.6)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3518"
         },
         {
-            "name": "CVE-2021-3537",
-            "description": "A vulnerability found in libxml2 in versions before 2.9.11 shows that it did not propagate errors while parsing XML mixed content, causing a NULL dereference. If an untrusted XML document was parsed in recovery mode and post-validated, the flaw could be used to crash the application. The highest threat from this vulnerability is to system availability.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3537",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -2573,8 +3813,11 @@
                     "value": "4.3"
                 }
             ],
+            "description": "A vulnerability found in libxml2 in versions before 2.9.11 shows that it did not propagate errors while parsing XML mixed content, causing a NULL dereference. If an untrusted XML document was parsed in recovery mode and post-validated, the flaw could be used to crash the application. The highest threat from this vulnerability is to system availability.",
+            "name": "CVE-2021-3537",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "libxml2",
@@ -2584,42 +3827,51 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (2.9.10+dfsg-6.6)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable (2.9.10+dfsg-6.7)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (2.9.4+dfsg1-6.1ubuntu1.4)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
+                                "focal",
+                                "Released (2.9.10+dfsg-5ubuntu0.20.04.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (2.9.10+dfsg-5ubuntu0.20.10.2)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.9.10+dfsg-6.3ubuntu0.1)"
+                            ],
+                            [
+                                "impish",
+                                "Not vulnerable (2.9.10+dfsg-6.7)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needs-triage)"
+                            ],
+                            [
+                                "trusty",
                                 "Released (2.9.1+dfsg1-3ubuntu4.13+esm2)"
+                            ],
+                            [
+                                "upstream",
+                                "Released (2.9.10+dfsg-6.6)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.9.3+dfsg1-1ubuntu0.7+esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3537"
         }
     ],
     "lz4": [
         {
-            "name": "CVE-2021-3520",
-            "description": "There's a flaw in lz4. An attacker who submits a crafted file to an application linked with lz4 may be able to trigger an integer overflow, leading to calling of memmove() on a negative size argument, causing an out-of-bounds write and/or a crash. The greatest impact of this flaw is to availability, with some potential impact to confidentiality and integrity as well.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3520",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -2638,8 +3890,11 @@
                     "value": "7.5"
                 }
             ],
+            "description": "There's a flaw in lz4. An attacker who submits a crafted file to an application linked with lz4 may be able to trigger an integer overflow, leading to calling of memmove() on a negative size argument, causing an out-of-bounds write and/or a crash. The greatest impact of this flaw is to availability, with some potential impact to confidentiality and integrity as well.",
+            "name": "CVE-2021-3520",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "lz4",
@@ -2649,46 +3904,51 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (1.9.3-2)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable (1.9.3-2)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (1.9.2-2ubuntu0.20.04.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (0.0~r131-2ubuntu3.1)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (0.0~r131-2ubuntu2+esm1)"
+                                "focal",
+                                "Released (1.9.2-2ubuntu0.20.04.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (1.9.2-2ubuntu0.20.10.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (1.9.3-1ubuntu0.1)"
+                            ],
+                            [
+                                "impish",
+                                "Not vulnerable (1.9.3-2)"
+                            ],
+                            [
+                                "precise",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
                                 "Released (0.0~r114-2ubuntu1+esm2)"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Released (1.9.3-2)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (0.0~r131-2ubuntu2+esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3520"
         }
     ],
     "nettle": [
         {
-            "name": "CVE-2021-20305",
-            "description": "A flaw was found in Nettle in versions before 3.7.2, where several Nettle signature verification functions (GOST DSA, EDDSA & ECDSA) result in the Elliptic Curve Cryptography point (ECC) multiply function being called with out-of-range scalers, possibly resulting in incorrect results. This flaw allows an attacker to force an invalid signature, causing an assertion failure or possible validation. The highest threat to this vulnerability is to confidentiality, integrity, as well as system availability.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-20305",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -2707,8 +3967,11 @@
                     "value": "6.8"
                 }
             ],
+            "description": "A flaw was found in Nettle in versions before 3.7.2, where several Nettle signature verification functions (GOST DSA, EDDSA & ECDSA) result in the Elliptic Curve Cryptography point (ECC) multiply function being called with out-of-range scalers, possibly resulting in incorrect results. This flaw allows an attacker to force an invalid signature, causing an assertion failure or possible validation. The highest threat to this vulnerability is to confidentiality, integrity, as well as system availability.",
+            "name": "CVE-2021-20305",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "nettle",
@@ -2718,46 +3981,51 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (3.7.2-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (3.7-2.1ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (3.5.1+really3.5.1-2ubuntu0.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (3.4-1ubuntu0.1)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (3.2-1ubuntu0.16.04.2)"
+                                "focal",
+                                "Released (3.5.1+really3.5.1-2ubuntu0.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (3.6-2ubuntu0.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (3.7-2.1ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (3.7-2.1ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
                                 "Needs triage"
                             ],
                             [
-                                "Patches:",
-                                "Upstream: Upstream: Upstream: Upstream: Upstream: Upstream: Upstream:"
+                                "upstream",
+                                "Released (3.7.2-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (3.2-1ubuntu0.16.04.2)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-20305"
         }
     ],
     "nss": [
         {
-            "name": "CVE-2021-43527",
-            "description": "NSS (Network Security Services) versions prior to 3.73 or 3.68.1 ESR are vulnerable to a heap overflow when handling DER-encoded DSA or RSA-PSS signatures. Applications using NSS for handling signatures encoded within CMS, S/MIME, PKCS \\#7, or PKCS \\#12 are likely to be impacted. Applications using NSS for certificate validation or other TLS, X.509, OCSP or CRL functionality may be impacted, depending on how they configure NSS. *Note: This vulnerability does NOT impact Mozilla Firefox.* However, email clients and PDF viewers that use NSS for signature verification, such as Thunderbird, LibreOffice, Evolution and Evince are believed to be impacted. This vulnerability affects NSS < 3.73 and NSS < 3.68.1.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-43527",
-            "severity": "HIGH",
             "attributes": [
                 {
                     "key": "package_version",
@@ -2776,8 +4044,13 @@
                     "value": "7.5"
                 }
             ],
+            "description": "NSS (Network Security Services) versions prior to 3.73 or 3.68.1 ESR are vulnerable to a heap overflow when handling DER-encoded DSA or RSA-PSS signatures. Applications using NSS for handling signatures encoded within CMS, S/MIME, PKCS \\#7, or PKCS \\#12 are likely to be impacted. Applications using NSS for certificate validation or other TLS, X.509, OCSP or CRL functionality may be impacted, depending on how they configure NSS. *Note: This vulnerability does NOT impact Mozilla Firefox.* However, email clients and PDF viewers that use NSS for signature verification, such as Thunderbird, LibreOffice, Evolution and Evince are believed to be impacted. This vulnerability affects NSS < 3.73 and NSS < 3.68.1.",
+            "name": "CVE-2021-43527",
             "scraped_data": [
                 {
+                    "notes": [
+                        "thunderbird 91.3.0 already shipped a work-around for this issue,\nwhich is now known as CVE-2021-43529, but thunderbird 91.4.0\nwill also fix the nss issue to prevent secondary attack vectors."
+                    ],
                     "status_table": {
                         "packages": [
                             "nss",
@@ -2787,44 +4060,43 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2:3.68-1ubuntu1.1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2:3.49.1-1ubuntu1.6)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (2:3.35-2ubuntu2.13)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2:3.28.4-0ubuntu0.16.04.14+esm2)"
+                                "focal",
+                                "Released (2:3.49.1-1ubuntu1.6)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Released (2:3.61-1ubuntu2.1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2:3.68-1ubuntu1.1)"
+                            ],
+                            [
+                                "trusty",
                                 "Released (2:3.28.4-0ubuntu0.14.04.5+esm10)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2:3.28.4-0ubuntu0.16.04.14+esm2)"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "thunderbird 91.3.0 already shipped a work-around for this issue,\nwhich is now known as CVE-2021-43529, but thunderbird 91.4.0\nwill also fix the nss issue to prevent secondary attack vectors."
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "HIGH",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-43527"
         }
     ],
     "openexr": [
         {
-            "name": "CVE-2021-3605",
-            "description": "There's a flaw in OpenEXR's rleUncompress functionality in versions prior to 3.0.5. An attacker who is able to submit a crafted file to an application linked with OpenEXR could cause an out-of-bounds read. The greatest risk from this flaw is to application availability.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3605",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -2843,8 +4115,11 @@
                     "value": "4.3"
                 }
             ],
+            "description": "There's a flaw in OpenEXR's rleUncompress functionality in versions prior to 3.0.5. An attacker who is able to submit a crafted file to an application linked with OpenEXR could cause an out-of-bounds read. The greatest risk from this flaw is to application availability.",
+            "name": "CVE-2021-3605",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "openexr",
@@ -2854,44 +4129,45 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (2.5.7-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (2.2.0-11.1ubuntu1.7)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.2.0-10ubuntu2.6+esm1)"
+                                "focal",
+                                "Needs triage"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
+                                "Needed"
+                            ],
+                            [
+                                "trusty",
                                 "Does not exist"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Released (2.5.7-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.2.0-10ubuntu2.6+esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3605"
         },
         {
-            "name": "CVE-2021-3933",
-            "description": "openexr: Integer-overflow in Imf_3_1::bytesPerDeepLineTable",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3933",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -2900,10 +4176,21 @@
                 {
                     "key": "package_name",
                     "value": "openexr"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "4.3"
                 }
             ],
+            "description": "An integer overflow could occur when OpenEXR processes a crafted file on systems where size_t < 64 bits. This could cause an invalid bytesPerLine and maxBytesPerLine value, which could lead to problems with application stability or lead to other attack paths.",
+            "name": "CVE-2021-3933",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "openexr",
@@ -2913,46 +4200,43 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (2.2.0-11.1ubuntu1.8)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.2.0-10ubuntu2.6+esm2)"
+                                "focal",
+                                "Needs triage"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
+                                "Needs triage"
+                            ],
+                            [
+                                "trusty",
                                 "Ignored (out of standard support)"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.2.0-10ubuntu2.6+esm2)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3933"
         }
     ],
     "openjdk-8": [
         {
-            "name": "CVE-2021-2341",
-            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Networking). Supported versions that are affected are Java SE: 7u301, 8u291, 11.0.11, 16.0.1; Oracle GraalVM Enterprise Edition: 20.3.2 and 21.1.0. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks require human interaction from a person other than the attacker. Successful attacks of this vulnerability can result in unauthorized read access to a subset of Java SE, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability does not apply to Java deployments, typically in servers, that load and run only trusted code (e.g., code installed by an administrator). CVSS 3.1 Base Score 3.1 (Confidentiality impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-2341",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -2971,8 +4255,13 @@
                     "value": "4.3"
                 }
             ],
+            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Networking). Supported versions that are affected are Java SE: 7u301, 8u291, 11.0.11, 16.0.1; Oracle GraalVM Enterprise Edition: 20.3.2 and 21.1.0. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks require human interaction from a person other than the attacker. Successful attacks of this vulnerability can result in unauthorized read access to a subset of Java SE, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability does not apply to Java deployments, typically in servers, that load and run only trusted code (e.g., code installed by an administrator). CVSS 3.1 Base Score 3.1 (Confidentiality impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N).",
+            "name": "CVE-2021-2341",
             "scraped_data": [
                 {
+                    "notes": [
+                        "the fix for this issue changes the FTP client\nbehavior in OpenJDK. See the Oracle release notes on the new\njdk.net.ftp.trustPasvAddress system property that can be set if\nthis breaks PASV commands from an application using the FTP client\nimplementation in OpenJDK."
+                    ],
                     "status_table": {
                         "packages": [
                             "openjdk-8",
@@ -2982,46 +4271,45 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable (8u302-b08-0ubuntu2)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (8u312-b07-0ubuntu1~20.04)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (8u312-b07-0ubuntu1~18.04)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (8u312-b07-0ubuntu1~16.04)"
+                                "focal",
+                                "Released (8u312-b07-0ubuntu1~20.04)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (8u312-b07-0ubuntu1~21.04)"
+                            ],
+                            [
+                                "impish",
+                                "Not vulnerable (8u302-b08-0ubuntu2)"
+                            ],
+                            [
+                                "trusty",
                                 "Does not exist"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (8u312-b07-0ubuntu1~16.04)"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "the fix for this issue changes the FTP client\nbehavior in OpenJDK. See the Oracle release notes on the new\njdk.net.ftp.trustPasvAddress system property that can be set if\nthis breaks PASV commands from an application using the FTP client\nimplementation in OpenJDK."
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-2341"
         },
         {
-            "name": "CVE-2021-2369",
-            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Library). Supported versions that are affected are Java SE: 7u301, 8u291, 11.0.11, 16.0.1; Oracle GraalVM Enterprise Edition: 20.3.2 and 21.1.0. Easily exploitable vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks require human interaction from a person other than the attacker. Successful attacks of this vulnerability can result in unauthorized update, insert or delete access to some of Java SE, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability does not apply to Java deployments, typically in servers, that load and run only trusted code (e.g., code installed by an administrator). CVSS 3.1 Base Score 4.3 (Integrity impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-2369",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -3040,8 +4328,13 @@
                     "value": "4.3"
                 }
             ],
+            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Library). Supported versions that are affected are Java SE: 7u301, 8u291, 11.0.11, 16.0.1; Oracle GraalVM Enterprise Edition: 20.3.2 and 21.1.0. Easily exploitable vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks require human interaction from a person other than the attacker. Successful attacks of this vulnerability can result in unauthorized update, insert or delete access to some of Java SE, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability does not apply to Java deployments, typically in servers, that load and run only trusted code (e.g., code installed by an administrator). CVSS 3.1 Base Score 4.3 (Integrity impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N).",
+            "name": "CVE-2021-2369",
             "scraped_data": [
                 {
+                    "notes": [
+                        "the fix for this issue changes OpenJDK's behavior such that\nJAR file with multiple manifest files to be treated as unsigned."
+                    ],
                     "status_table": {
                         "packages": [
                             "openjdk-8",
@@ -3051,46 +4344,45 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable (8u302-b08-0ubuntu2)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (8u312-b07-0ubuntu1~20.04)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (8u312-b07-0ubuntu1~18.04)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (8u312-b07-0ubuntu1~16.04)"
+                                "focal",
+                                "Released (8u312-b07-0ubuntu1~20.04)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (8u312-b07-0ubuntu1~21.04)"
+                            ],
+                            [
+                                "impish",
+                                "Not vulnerable (8u302-b08-0ubuntu2)"
+                            ],
+                            [
+                                "trusty",
                                 "Does not exist"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (8u312-b07-0ubuntu1~16.04)"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "the fix for this issue changes OpenJDK's behavior such that\nJAR file with multiple manifest files to be treated as unsigned."
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-2369"
         },
         {
-            "name": "CVE-2021-2388",
-            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Hotspot). Supported versions that are affected are Java SE: 8u291, 11.0.11, 16.0.1; Oracle GraalVM Enterprise Edition: 20.3.2 and 21.1.0. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks require human interaction from a person other than the attacker. Successful attacks of this vulnerability can result in takeover of Java SE, Oracle GraalVM Enterprise Edition. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability does not apply to Java deployments, typically in servers, that load and run only trusted code (e.g., code installed by an administrator). CVSS 3.1 Base Score 7.5 (Confidentiality, Integrity and Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-2388",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -3109,8 +4401,11 @@
                     "value": "5.1"
                 }
             ],
+            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Hotspot). Supported versions that are affected are Java SE: 8u291, 11.0.11, 16.0.1; Oracle GraalVM Enterprise Edition: 20.3.2 and 21.1.0. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks require human interaction from a person other than the attacker. Successful attacks of this vulnerability can result in takeover of Java SE, Oracle GraalVM Enterprise Edition. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability does not apply to Java deployments, typically in servers, that load and run only trusted code (e.g., code installed by an administrator). CVSS 3.1 Base Score 7.5 (Confidentiality, Integrity and Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H).",
+            "name": "CVE-2021-2388",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "openjdk-8",
@@ -3120,44 +4415,45 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Not vulnerable (8u302-b08-0ubuntu2)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (8u312-b07-0ubuntu1~20.04)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (8u312-b07-0ubuntu1~18.04)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (8u312-b07-0ubuntu1~16.04)"
+                                "focal",
+                                "Released (8u312-b07-0ubuntu1~20.04)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (8u312-b07-0ubuntu1~21.04)"
+                            ],
+                            [
+                                "impish",
+                                "Not vulnerable (8u302-b08-0ubuntu2)"
+                            ],
+                            [
+                                "trusty",
                                 "Does not exist"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (8u312-b07-0ubuntu1~16.04)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-2388"
         },
         {
-            "name": "CVE-2021-35550",
-            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: JSSE). Supported versions that are affected are Java SE: 7u311, 8u301, 11.0.12; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Difficult to exploit vulnerability allows unauthenticated attacker with network access via TLS to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized access to critical data or complete access to all Java SE, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability can also be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. CVSS 3.1 Base Score 5.9 (Confidentiality impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35550",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -3176,53 +4472,124 @@
                     "value": "7.1"
                 }
             ],
+            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: JSSE). Supported versions that are affected are Java SE: 7u311, 8u301, 11.0.12; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Difficult to exploit vulnerability allows unauthenticated attacker with network access via TLS to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized access to critical data or complete access to all Java SE, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability can also be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. CVSS 3.1 Base Score 5.9 (Confidentiality impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N).",
+            "name": "CVE-2021-35550",
             "scraped_data": [
                 {
-                    "status_table": {
-                        "packages": [
-                            "openjdk-8",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (8u312-b07-0ubuntu1~21.10)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (8u312-b07-0ubuntu1~20.04)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (8u312-b07-0ubuntu1~18.04)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (8u312-b07-0ubuntu1~16.04)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Does not exist"
-                            ]
-                        ]
-                    },
                     "notes": [
                         "the fix for this issue changes OpenJDK to prioritize ciphers with\nforward secrecy. See the JDK-8163326 bug for more details."
-                    ]
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "openjdk-8",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (8u312-b07-0ubuntu1~18.04)"
+                            ],
+                            [
+                                "focal",
+                                "Released (8u312-b07-0ubuntu1~20.04)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (8u312-b07-0ubuntu1~21.04)"
+                            ],
+                            [
+                                "impish",
+                                "Released (8u312-b07-0ubuntu1~21.10)"
+                            ],
+                            [
+                                "trusty",
+                                "Does not exist"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (8u312-b07-0ubuntu1~16.04)"
+                            ]
+                        ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35550"
         },
         {
-            "name": "CVE-2021-35556",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "8u292-b10-0ubuntu1~16.04.1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openjdk-8"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
             "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Swing). Supported versions that are affected are Java SE: 7u311, 8u301, 11.0.12, 17; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Easily exploitable vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized ability to cause a partial denial of service (partial DOS) of Java SE, Oracle GraalVM Enterprise Edition. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability does not apply to Java deployments, typically in servers, that load and run only trusted code (e.g., code installed by an administrator). CVSS 3.1 Base Score 5.3 (Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35556",
+            "name": "CVE-2021-35556",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "openjdk-8",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (8u312-b07-0ubuntu1~18.04)"
+                            ],
+                            [
+                                "focal",
+                                "Released (8u312-b07-0ubuntu1~20.04)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (8u312-b07-0ubuntu1~21.04)"
+                            ],
+                            [
+                                "impish",
+                                "Released (8u312-b07-0ubuntu1~21.10)"
+                            ],
+                            [
+                                "trusty",
+                                "Does not exist"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (8u312-b07-0ubuntu1~16.04)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35556"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -3241,55 +4608,55 @@
                     "value": "5"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "openjdk-8",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (8u312-b07-0ubuntu1~21.10)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (8u312-b07-0ubuntu1~20.04)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (8u312-b07-0ubuntu1~18.04)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (8u312-b07-0ubuntu1~16.04)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Does not exist"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2021-35559",
             "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Swing). Supported versions that are affected are Java SE: 7u311, 8u301, 11.0.12, 17; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Easily exploitable vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized ability to cause a partial denial of service (partial DOS) of Java SE, Oracle GraalVM Enterprise Edition. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability can also be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. CVSS 3.1 Base Score 5.3 (Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35559",
+            "name": "CVE-2021-35559",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "openjdk-8",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (8u312-b07-0ubuntu1~18.04)"
+                            ],
+                            [
+                                "focal",
+                                "Released (8u312-b07-0ubuntu1~20.04)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (8u312-b07-0ubuntu1~21.04)"
+                            ],
+                            [
+                                "impish",
+                                "Released (8u312-b07-0ubuntu1~21.10)"
+                            ],
+                            [
+                                "trusty",
+                                "Does not exist"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (8u312-b07-0ubuntu1~16.04)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35559"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -3308,75 +4675,11 @@
                     "value": "5"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "openjdk-8",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (8u312-b07-0ubuntu1~21.10)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (8u312-b07-0ubuntu1~20.04)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (8u312-b07-0ubuntu1~18.04)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (8u312-b07-0ubuntu1~16.04)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Does not exist"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2021-35561",
             "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Utility). Supported versions that are affected are Java SE: 7u311, 8u301, 11.0.12, 17; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Easily exploitable vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized ability to cause a partial denial of service (partial DOS) of Java SE, Oracle GraalVM Enterprise Edition. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability can also be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. CVSS 3.1 Base Score 5.3 (Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35561",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "8u292-b10-0ubuntu1~16.04.1"
-                },
-                {
-                    "key": "package_name",
-                    "value": "openjdk-8"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "5"
-                }
-            ],
+            "name": "CVE-2021-35561",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "openjdk-8",
@@ -3386,44 +4689,41 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (8u312-b07-0ubuntu1~21.10)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (8u312-b07-0ubuntu1~20.04)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (8u312-b07-0ubuntu1~18.04)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (8u312-b07-0ubuntu1~16.04)"
+                                "focal",
+                                "Released (8u312-b07-0ubuntu1~20.04)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Released (8u312-b07-0ubuntu1~21.04)"
+                            ],
+                            [
+                                "impish",
+                                "Released (8u312-b07-0ubuntu1~21.10)"
+                            ],
+                            [
+                                "trusty",
                                 "Does not exist"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (8u312-b07-0ubuntu1~16.04)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35561"
         },
         {
-            "name": "CVE-2021-35564",
-            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Keytool). Supported versions that are affected are Java SE: 7u311, 8u301, 11.0.12, 17; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Easily exploitable vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized update, insert or delete access to some of Java SE, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability can also be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. CVSS 3.1 Base Score 5.3 (Integrity impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35564",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -3442,8 +4742,11 @@
                     "value": "5"
                 }
             ],
+            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Keytool). Supported versions that are affected are Java SE: 7u311, 8u301, 11.0.12, 17; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Easily exploitable vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized update, insert or delete access to some of Java SE, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability can also be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. CVSS 3.1 Base Score 5.3 (Integrity impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N).",
+            "name": "CVE-2021-35564",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "openjdk-8",
@@ -3453,40 +4756,41 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (8u312-b07-0ubuntu1~21.10)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (8u312-b07-0ubuntu1~20.04)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (8u312-b07-0ubuntu1~18.04)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (8u312-b07-0ubuntu1~16.04)"
+                                "focal",
+                                "Released (8u312-b07-0ubuntu1~20.04)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Released (8u312-b07-0ubuntu1~21.04)"
+                            ],
+                            [
+                                "impish",
+                                "Released (8u312-b07-0ubuntu1~21.10)"
+                            ],
+                            [
+                                "trusty",
                                 "Does not exist"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (8u312-b07-0ubuntu1~16.04)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35564"
         },
         {
-            "name": "CVE-2021-35565",
-            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: JSSE). Supported versions that are affected are Java SE: 7u311, 8u301, 11.0.12; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Easily exploitable vulnerability allows unauthenticated attacker with network access via TLS to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized ability to cause a partial denial of service (partial DOS) of Java SE, Oracle GraalVM Enterprise Edition. Note: This vulnerability can only be exploited by supplying data to APIs in the specified Component without using Untrusted Java Web Start applications or Untrusted Java applets, such as through a web service. CVSS 3.1 Base Score 5.3 (Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35565",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -3505,8 +4809,11 @@
                     "value": "5"
                 }
             ],
+            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: JSSE). Supported versions that are affected are Java SE: 7u311, 8u301, 11.0.12; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Easily exploitable vulnerability allows unauthenticated attacker with network access via TLS to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized ability to cause a partial denial of service (partial DOS) of Java SE, Oracle GraalVM Enterprise Edition. Note: This vulnerability can only be exploited by supplying data to APIs in the specified Component without using Untrusted Java Web Start applications or Untrusted Java applets, such as through a web service. CVSS 3.1 Base Score 5.3 (Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L).",
+            "name": "CVE-2021-35565",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "openjdk-8",
@@ -3516,44 +4823,41 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (8u312-b07-0ubuntu1~21.10)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (8u312-b07-0ubuntu1~20.04)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (8u312-b07-0ubuntu1~18.04)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (8u312-b07-0ubuntu1~16.04)"
+                                "focal",
+                                "Released (8u312-b07-0ubuntu1~20.04)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Released (8u312-b07-0ubuntu1~21.04)"
+                            ],
+                            [
+                                "impish",
+                                "Released (8u312-b07-0ubuntu1~21.10)"
+                            ],
+                            [
+                                "trusty",
                                 "Does not exist"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (8u312-b07-0ubuntu1~16.04)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35565"
         },
         {
-            "name": "CVE-2021-35567",
-            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Libraries). Supported versions that are affected are Java SE: 8u301, 11.0.12, 17; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Easily exploitable vulnerability allows low privileged attacker with network access via Kerberos to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks require human interaction from a person other than the attacker and while the vulnerability is in Java SE, Oracle GraalVM Enterprise Edition, attacks may significantly impact additional products. Successful attacks of this vulnerability can result in unauthorized access to critical data or complete access to all Java SE, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability can also be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. CVSS 3.1 Base Score 6.8 (Confidentiality impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:N/A:N).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35567",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -3572,8 +4876,11 @@
                     "value": "6.3"
                 }
             ],
+            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Libraries). Supported versions that are affected are Java SE: 8u301, 11.0.12, 17; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Easily exploitable vulnerability allows low privileged attacker with network access via Kerberos to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks require human interaction from a person other than the attacker and while the vulnerability is in Java SE, Oracle GraalVM Enterprise Edition, attacks may significantly impact additional products. Successful attacks of this vulnerability can result in unauthorized access to critical data or complete access to all Java SE, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability can also be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. CVSS 3.1 Base Score 6.8 (Confidentiality impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:N/A:N).",
+            "name": "CVE-2021-35567",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "openjdk-8",
@@ -3583,44 +4890,108 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (8u312-b07-0ubuntu1~21.10)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (8u312-b07-0ubuntu1~20.04)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (8u312-b07-0ubuntu1~18.04)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (8u312-b07-0ubuntu1~16.04)"
+                                "focal",
+                                "Released (8u312-b07-0ubuntu1~20.04)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Released (8u312-b07-0ubuntu1~21.04)"
+                            ],
+                            [
+                                "impish",
+                                "Released (8u312-b07-0ubuntu1~21.10)"
+                            ],
+                            [
+                                "trusty",
                                 "Does not exist"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (8u312-b07-0ubuntu1~16.04)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35567"
         },
         {
-            "name": "CVE-2021-35578",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "8u292-b10-0ubuntu1~16.04.1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openjdk-8"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
             "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: JSSE). Supported versions that are affected are Java SE: 8u301, 11.0.12, 17; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Easily exploitable vulnerability allows unauthenticated attacker with network access via TLS to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized ability to cause a partial denial of service (partial DOS) of Java SE, Oracle GraalVM Enterprise Edition. Note: This vulnerability can only be exploited by supplying data to APIs in the specified Component without using Untrusted Java Web Start applications or Untrusted Java applets, such as through a web service. CVSS 3.1 Base Score 5.3 (Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35578",
+            "name": "CVE-2021-35578",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "openjdk-8",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (8u312-b07-0ubuntu1~18.04)"
+                            ],
+                            [
+                                "focal",
+                                "Released (8u312-b07-0ubuntu1~20.04)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (8u312-b07-0ubuntu1~21.04)"
+                            ],
+                            [
+                                "impish",
+                                "Released (8u312-b07-0ubuntu1~21.10)"
+                            ],
+                            [
+                                "trusty",
+                                "Does not exist"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (8u312-b07-0ubuntu1~16.04)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35578"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -3639,75 +5010,11 @@
                     "value": "5"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "openjdk-8",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (8u312-b07-0ubuntu1~21.10)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (8u312-b07-0ubuntu1~20.04)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (8u312-b07-0ubuntu1~18.04)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (8u312-b07-0ubuntu1~16.04)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Does not exist"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2021-35586",
             "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: ImageIO). Supported versions that are affected are Java SE: 7u311, 8u301, 11.0.12, 17; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Easily exploitable vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized ability to cause a partial denial of service (partial DOS) of Java SE, Oracle GraalVM Enterprise Edition. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability can also be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. CVSS 3.1 Base Score 5.3 (Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35586",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "8u292-b10-0ubuntu1~16.04.1"
-                },
-                {
-                    "key": "package_name",
-                    "value": "openjdk-8"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "5"
-                }
-            ],
+            "name": "CVE-2021-35586",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "openjdk-8",
@@ -3717,44 +5024,41 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (8u312-b07-0ubuntu1~21.10)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (8u312-b07-0ubuntu1~20.04)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (8u312-b07-0ubuntu1~18.04)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (8u312-b07-0ubuntu1~16.04)"
+                                "focal",
+                                "Released (8u312-b07-0ubuntu1~20.04)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Released (8u312-b07-0ubuntu1~21.04)"
+                            ],
+                            [
+                                "impish",
+                                "Released (8u312-b07-0ubuntu1~21.10)"
+                            ],
+                            [
+                                "trusty",
                                 "Does not exist"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (8u312-b07-0ubuntu1~16.04)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35586"
         },
         {
-            "name": "CVE-2021-35588",
-            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Hotspot). Supported versions that are affected are Java SE: 7u311, 8u301; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks require human interaction from a person other than the attacker. Successful attacks of this vulnerability can result in unauthorized ability to cause a partial denial of service (partial DOS) of Java SE, Oracle GraalVM Enterprise Edition. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability can also be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. CVSS 3.1 Base Score 3.1 (Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:L).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35588",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -3773,8 +5077,11 @@
                     "value": "2.6"
                 }
             ],
+            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: Hotspot). Supported versions that are affected are Java SE: 7u311, 8u301; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks require human interaction from a person other than the attacker. Successful attacks of this vulnerability can result in unauthorized ability to cause a partial denial of service (partial DOS) of Java SE, Oracle GraalVM Enterprise Edition. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability can also be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. CVSS 3.1 Base Score 3.1 (Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:L).",
+            "name": "CVE-2021-35588",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "openjdk-8",
@@ -3784,44 +5091,41 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (8u312-b07-0ubuntu1~21.10)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (8u312-b07-0ubuntu1~20.04)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (8u312-b07-0ubuntu1~18.04)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (8u312-b07-0ubuntu1~16.04)"
+                                "focal",
+                                "Released (8u312-b07-0ubuntu1~20.04)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Released (8u312-b07-0ubuntu1~21.04)"
+                            ],
+                            [
+                                "impish",
+                                "Released (8u312-b07-0ubuntu1~21.10)"
+                            ],
+                            [
+                                "trusty",
                                 "Does not exist"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (8u312-b07-0ubuntu1~16.04)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35588"
         },
         {
-            "name": "CVE-2021-35603",
-            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: JSSE). Supported versions that are affected are Java SE: 7u311, 8u301, 11.0.12, 17; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Difficult to exploit vulnerability allows unauthenticated attacker with network access via TLS to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized read access to a subset of Java SE, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability can also be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. CVSS 3.1 Base Score 3.7 (Confidentiality impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35603",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -3840,8 +5144,11 @@
                     "value": "4.3"
                 }
             ],
+            "description": "Vulnerability in the Java SE, Oracle GraalVM Enterprise Edition product of Oracle Java SE (component: JSSE). Supported versions that are affected are Java SE: 7u311, 8u301, 11.0.12, 17; Oracle GraalVM Enterprise Edition: 20.3.3 and 21.2.0. Difficult to exploit vulnerability allows unauthenticated attacker with network access via TLS to compromise Java SE, Oracle GraalVM Enterprise Edition. Successful attacks of this vulnerability can result in unauthorized read access to a subset of Java SE, Oracle GraalVM Enterprise Edition accessible data. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability can also be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. CVSS 3.1 Base Score 3.7 (Confidentiality impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N).",
+            "name": "CVE-2021-35603",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "openjdk-8",
@@ -3851,46 +5158,118 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (8u312-b07-0ubuntu1~21.10)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (8u312-b07-0ubuntu1~20.04)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (8u312-b07-0ubuntu1~18.04)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (8u312-b07-0ubuntu1~16.04)"
+                                "focal",
+                                "Released (8u312-b07-0ubuntu1~20.04)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Released (8u312-b07-0ubuntu1~21.04)"
+                            ],
+                            [
+                                "impish",
+                                "Released (8u312-b07-0ubuntu1~21.10)"
+                            ],
+                            [
+                                "trusty",
                                 "Does not exist"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (8u312-b07-0ubuntu1~16.04)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-35603"
         }
     ],
     "openldap": [
         {
-            "name": "CVE-2020-36221",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.4.42+dfsg-2ubuntu3.11"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openldap"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
             "description": "An integer underflow was discovered in OpenLDAP before 2.4.57 leading to slapd crashes in the Certificate Exact Assertion processing, resulting in denial of service (schema_init.c serialNumberAndIssuerCheck).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36221",
+            "name": "CVE-2020-36221",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "groovy",
+                                "Released (2.4.53+dfsg-1ubuntu1.3)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needed)"
+                            ],
+                            [
+                                "trusty",
+                                "Needed"
+                            ],
+                            [
+                                "upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36221"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -3909,55 +5288,63 @@
                     "value": "5"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "openldap",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (2.4.57+dfsg-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2.4.57+dfsg-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.4.49+dfsg-2ubuntu1.6)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2.4.45+dfsg-1ubuntu1.9)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.4.42+dfsg-2ubuntu3.12)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream: Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2020-36222",
             "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to an assertion failure in slapd in the saslAuthzTo validation, resulting in denial of service.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36222",
+            "name": "CVE-2020-36222",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "groovy",
+                                "Released (2.4.53+dfsg-1ubuntu1.3)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needed)"
+                            ],
+                            [
+                                "trusty",
+                                "Needed"
+                            ],
+                            [
+                                "upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36222"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -3976,55 +5363,63 @@
                     "value": "5"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "openldap",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (2.4.57+dfsg-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2.4.57+dfsg-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.4.49+dfsg-2ubuntu1.6)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2.4.45+dfsg-1ubuntu1.9)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.4.42+dfsg-2ubuntu3.12)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream: Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2020-36223",
             "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to a slapd crash in the Values Return Filter control handling, resulting in denial of service (double free and out-of-bounds read).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36223",
+            "name": "CVE-2020-36223",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "groovy",
+                                "Released (2.4.53+dfsg-1ubuntu1.3)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needed)"
+                            ],
+                            [
+                                "trusty",
+                                "Needed"
+                            ],
+                            [
+                                "upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36223"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -4043,55 +5438,63 @@
                     "value": "5"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "openldap",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (2.4.57+dfsg-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2.4.57+dfsg-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.4.49+dfsg-2ubuntu1.6)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2.4.45+dfsg-1ubuntu1.9)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.4.42+dfsg-2ubuntu3.12)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2020-36224",
             "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to an invalid pointer free and slapd crash in the saslAuthzTo processing, resulting in denial of service.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36224",
+            "name": "CVE-2020-36224",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "groovy",
+                                "Released (2.4.53+dfsg-1ubuntu1.3)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needed)"
+                            ],
+                            [
+                                "trusty",
+                                "Needed"
+                            ],
+                            [
+                                "upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36224"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -4110,55 +5513,63 @@
                     "value": "5"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "openldap",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (2.4.57+dfsg-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2.4.57+dfsg-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.4.49+dfsg-2ubuntu1.6)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2.4.45+dfsg-1ubuntu1.9)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.4.42+dfsg-2ubuntu3.12)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream: Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2020-36225",
             "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to a double free and slapd crash in the saslAuthzTo processing, resulting in denial of service.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36225",
+            "name": "CVE-2020-36225",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "groovy",
+                                "Released (2.4.53+dfsg-1ubuntu1.3)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needed)"
+                            ],
+                            [
+                                "trusty",
+                                "Needed"
+                            ],
+                            [
+                                "upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36225"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -4177,55 +5588,63 @@
                     "value": "5"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "openldap",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (2.4.57+dfsg-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2.4.57+dfsg-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.4.49+dfsg-2ubuntu1.6)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2.4.45+dfsg-1ubuntu1.9)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.4.42+dfsg-2ubuntu3.12)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2020-36226",
             "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to a memch->bv_len miscalculation and slapd crash in the saslAuthzTo processing, resulting in denial of service.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36226",
+            "name": "CVE-2020-36226",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "groovy",
+                                "Released (2.4.53+dfsg-1ubuntu1.3)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needed)"
+                            ],
+                            [
+                                "trusty",
+                                "Needed"
+                            ],
+                            [
+                                "upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36226"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -4244,55 +5663,63 @@
                     "value": "5"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "openldap",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (2.4.57+dfsg-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2.4.57+dfsg-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.4.49+dfsg-2ubuntu1.6)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2.4.45+dfsg-1ubuntu1.9)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.4.42+dfsg-2ubuntu3.12)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2020-36227",
             "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading to an infinite loop in slapd with the cancel_extop Cancel operation, resulting in denial of service.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36227",
+            "name": "CVE-2020-36227",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "groovy",
+                                "Released (2.4.53+dfsg-1ubuntu1.3)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needed)"
+                            ],
+                            [
+                                "trusty",
+                                "Needed"
+                            ],
+                            [
+                                "upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36227"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -4311,55 +5738,63 @@
                     "value": "5"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "openldap",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (2.4.57+dfsg-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2.4.57+dfsg-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.4.49+dfsg-2ubuntu1.6)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2.4.45+dfsg-1ubuntu1.9)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.4.42+dfsg-2ubuntu3.12)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2020-36228",
             "description": "An integer underflow was discovered in OpenLDAP before 2.4.57 leading to a slapd crash in the Certificate List Exact Assertion processing, resulting in denial of service.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36228",
+            "name": "CVE-2020-36228",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "groovy",
+                                "Released (2.4.53+dfsg-1ubuntu1.3)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needed)"
+                            ],
+                            [
+                                "trusty",
+                                "Needed"
+                            ],
+                            [
+                                "upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36228"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -4378,55 +5813,63 @@
                     "value": "5"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "openldap",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (2.4.57+dfsg-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2.4.57+dfsg-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.4.49+dfsg-2ubuntu1.6)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2.4.45+dfsg-1ubuntu1.9)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.4.42+dfsg-2ubuntu3.12)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2020-36229",
             "description": "A flaw was discovered in ldap_X509dn2bv in OpenLDAP before 2.4.57 leading to a slapd crash in the X.509 DN parsing in ad_keystring, resulting in denial of service.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36229",
+            "name": "CVE-2020-36229",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "openldap",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.4.45+dfsg-1ubuntu1.9)"
+                            ],
+                            [
+                                "focal",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
+                            ],
+                            [
+                                "groovy",
+                                "Released (2.4.53+dfsg-1ubuntu1.3)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needed)"
+                            ],
+                            [
+                                "trusty",
+                                "Needed"
+                            ],
+                            [
+                                "upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36229"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -4445,75 +5888,11 @@
                     "value": "5"
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "openldap",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (2.4.57+dfsg-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2.4.57+dfsg-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.4.49+dfsg-2ubuntu1.6)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2.4.45+dfsg-1ubuntu1.9)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.4.42+dfsg-2ubuntu3.12)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2020-36230",
             "description": "A flaw was discovered in OpenLDAP before 2.4.57 leading in an assertion failure in slapd in the X.509 DN parsing in decode.c ber_next_element, resulting in denial of service.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36230",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "2.4.42+dfsg-2ubuntu3.11"
-                },
-                {
-                    "key": "package_name",
-                    "value": "openldap"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "5"
-                }
-            ],
+            "name": "CVE-2020-36230",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "openldap",
@@ -4523,44 +5902,49 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (2.4.57+dfsg-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2.4.57+dfsg-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.4.49+dfsg-2ubuntu1.6)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (2.4.45+dfsg-1ubuntu1.9)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.4.42+dfsg-2ubuntu3.12)"
+                                "focal",
+                                "Released (2.4.49+dfsg-2ubuntu1.6)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (2.4.53+dfsg-1ubuntu1.3)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needed)"
+                            ],
+                            [
+                                "trusty",
                                 "Needed"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Released (2.4.57+dfsg-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.4.42+dfsg-2ubuntu3.12)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-36230"
         },
         {
-            "name": "CVE-2021-27212",
-            "description": "In OpenLDAP through 2.4.57 and 2.5.x through 2.5.1alpha, an assertion failure in slapd can occur in the issuerAndThisUpdateCheck function via a crafted packet, resulting in a denial of service (daemon exit) via a short timestamp. This is related to schema_init.c and checkTime.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-27212",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -4579,8 +5963,11 @@
                     "value": "5"
                 }
             ],
+            "description": "In OpenLDAP through 2.4.57 and 2.5.x through 2.5.1alpha, an assertion failure in slapd can occur in the issuerAndThisUpdateCheck function via a crafted packet, resulting in a denial of service (daemon exit) via a short timestamp. This is related to schema_init.c and checkTime.",
+            "name": "CVE-2021-27212",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "openldap",
@@ -4590,46 +5977,51 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (2.4.57+dfsg-2)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2.4.57+dfsg-2ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2.4.49+dfsg-2ubuntu1.7)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (2.4.45+dfsg-1ubuntu1.10)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2.4.42+dfsg-2ubuntu3.13)"
+                                "focal",
+                                "Released (2.4.49+dfsg-2ubuntu1.7)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (2.4.53+dfsg-1ubuntu1.4)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (2.4.57+dfsg-2ubuntu1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needed)"
+                            ],
+                            [
+                                "trusty",
                                 "Needed"
                             ],
                             [
-                                "Patches:",
-                                "Upstream: Upstream:"
+                                "upstream",
+                                "Released (2.4.57+dfsg-2)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.4.42+dfsg-2ubuntu3.13)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-27212"
         }
     ],
     "openssl": [
         {
-            "name": "CVE-2021-23841",
-            "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-23841",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -4648,8 +6040,13 @@
                     "value": "4.3"
                 }
             ],
+            "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack. The function X509_issuer_and_serial_hash() is never directly called by OpenSSL itself so applications are only vulnerable if they use this function directly and they use it on certificates that may have been obtained from untrusted sources. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).",
+            "name": "CVE-2021-23841",
             "scraped_data": [
                 {
+                    "notes": [
+                        "edk2 doesn't use the affected function"
+                    ],
                     "status_table": {
                         "packages": [
                             "openssl",
@@ -4659,111 +6056,41 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (1.1.1j)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (1.1.1f-1ubuntu2.2)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (1.1.1-1ubuntu2.1~18.04.8)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (1.0.2g-1ubuntu4.19)"
+                                "focal",
+                                "Released (1.1.1f-1ubuntu2.2)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (1.1.1f-1ubuntu4.2)"
+                            ],
+                            [
+                                "precise",
+                                "Released (1.0.1-4ubuntu5.45)"
+                            ],
+                            [
+                                "trusty",
                                 "Released (1.0.1f-1ubuntu2.27+esm2)"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Released (1.1.1j)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (1.0.2g-1ubuntu4.19)"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "edk2 doesn't use the affected function"
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "CVE-2021-3712",
-            "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3712",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "1.0.2g-1ubuntu4.18"
-                },
-                {
-                    "key": "package_name",
-                    "value": "openssl"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:M/Au:N/C:P/I:N/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "5.8"
+                    }
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "openssl",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (1.1.1l-1ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (1.1.1f-1ubuntu2.8)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (1.1.1-1ubuntu2.1~18.04.13)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (1.0.2g-1ubuntu4.20+esm1)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Released (1.0.1f-1ubuntu2.27+esm4)"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": [
-                        "in 1.0.2, this bug is in X509_CERT_AUX_print()\nlist of commits below is incomplete"
-                    ]
-                }
-            ]
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-23841"
         },
         {
-            "name": "CVE-2021-3712",
-            "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3712",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -4782,8 +6109,13 @@
                     "value": "5.8"
                 }
             ],
+            "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
+            "name": "CVE-2021-3712",
             "scraped_data": [
                 {
+                    "notes": [
+                        "in 1.0.2, this bug is in X509_CERT_AUX_print()\nlist of commits below is incomplete"
+                    ],
                     "status_table": {
                         "packages": [
                             "openssl",
@@ -4793,48 +6125,238 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (1.1.1l-1ubuntu1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (1.1.1f-1ubuntu2.8)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (1.1.1-1ubuntu2.1~18.04.13)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (1.0.2g-1ubuntu4.20+esm1)"
+                                "focal",
+                                "Released (1.1.1f-1ubuntu2.8)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "hirsute",
+                                "Released (1.1.1j-1ubuntu3.5)"
+                            ],
+                            [
+                                "impish",
+                                "Released (1.1.1l-1ubuntu1)"
+                            ],
+                            [
+                                "trusty",
                                 "Released (1.0.1f-1ubuntu2.27+esm4)"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (1.0.2g-1ubuntu4.20+esm1)"
                             ]
                         ]
-                    },
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3712"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "1.0.2g-1ubuntu4.18"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openssl"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:P/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5.8"
+                }
+            ],
+            "description": "ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own \"d2i\" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the \"data\" and \"length\" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the \"data\" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).",
+            "name": "CVE-2021-3712",
+            "scraped_data": [
+                {
                     "notes": [
                         "in 1.0.2, this bug is in X509_CERT_AUX_print()\nlist of commits below is incomplete"
-                    ]
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "openssl",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (1.1.1-1ubuntu2.1~18.04.13)"
+                            ],
+                            [
+                                "focal",
+                                "Released (1.1.1f-1ubuntu2.8)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (1.1.1j-1ubuntu3.5)"
+                            ],
+                            [
+                                "impish",
+                                "Released (1.1.1l-1ubuntu1)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (1.0.1f-1ubuntu2.27+esm4)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (1.0.2g-1ubuntu4.20+esm1)"
+                            ]
+                        ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3712"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "1.0.2g-1ubuntu4.20"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openssl"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "description": "The BN_mod_sqrt() function, which computes a modular square root, contains a bug that can cause it to loop forever for non-prime moduli. Internally this function is used when parsing certificates that contain elliptic curve public keys in compressed form or explicit elliptic curve parameters with a base point encoded in compressed form. It is possible to trigger the infinite loop by crafting a certificate that has invalid explicit curve parameters. Since certificate parsing happens prior to verification of the certificate signature, any process that parses an externally supplied certificate may thus be subject to a denial of service attack. The infinite loop can also be reached when parsing crafted private keys as they can contain explicit elliptic curve parameters. Thus vulnerable situations include: - TLS clients consuming server certificates - TLS servers consuming client certificates - Hosting providers taking certificates or private keys from customers - Certificate authorities parsing certification requests from subscribers - Anything else which parses ASN.1 elliptic curve parameters Also any other applications that use the BN_mod_sqrt() where the attacker can control the parameter values are vulnerable to this DoS issue. In the OpenSSL 1.0.2 version the public key is not parsed during initial parsing of the certificate which makes it slightly harder to trigger the infinite loop. However any operation which requires the public key from the certificate will trigger the infinite loop. In particular the attacker can use a self-signed certificate to trigger the loop during verification of the certificate signature. This issue affects OpenSSL versions 1.0.2, 1.1.1 and 3.0. It was addressed in the releases of 1.1.1n and 3.0.2 on the 15th March 2022. Fixed in OpenSSL 3.0.2 (Affected 3.0.0,3.0.1). Fixed in OpenSSL 1.1.1n (Affected 1.1.1-1.1.1m). Fixed in OpenSSL 1.0.2zd (Affected 1.0.2-1.0.2zc).",
+            "name": "CVE-2022-0778",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "openssl",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (1.1.1-1ubuntu2.1~18.04.15)"
+                            ],
+                            [
+                                "focal",
+                                "Released (1.1.1f-1ubuntu2.12)"
+                            ],
+                            [
+                                "impish",
+                                "Released (1.1.1l-1ubuntu1.2)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (1.0.1f-1ubuntu2.27+esm5)"
+                            ],
+                            [
+                                "upstream",
+                                "Released (1.1.1n,3.0.2)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (1.0.2g-1ubuntu4.20+esm2)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "HIGH",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-0778"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "1.0.2g-1ubuntu4.18"
+                },
+                {
+                    "key": "package_name",
+                    "value": "openssl"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "description": "The BN_mod_sqrt() function, which computes a modular square root, contains a bug that can cause it to loop forever for non-prime moduli. Internally this function is used when parsing certificates that contain elliptic curve public keys in compressed form or explicit elliptic curve parameters with a base point encoded in compressed form. It is possible to trigger the infinite loop by crafting a certificate that has invalid explicit curve parameters. Since certificate parsing happens prior to verification of the certificate signature, any process that parses an externally supplied certificate may thus be subject to a denial of service attack. The infinite loop can also be reached when parsing crafted private keys as they can contain explicit elliptic curve parameters. Thus vulnerable situations include: - TLS clients consuming server certificates - TLS servers consuming client certificates - Hosting providers taking certificates or private keys from customers - Certificate authorities parsing certification requests from subscribers - Anything else which parses ASN.1 elliptic curve parameters Also any other applications that use the BN_mod_sqrt() where the attacker can control the parameter values are vulnerable to this DoS issue. In the OpenSSL 1.0.2 version the public key is not parsed during initial parsing of the certificate which makes it slightly harder to trigger the infinite loop. However any operation which requires the public key from the certificate will trigger the infinite loop. In particular the attacker can use a self-signed certificate to trigger the loop during verification of the certificate signature. This issue affects OpenSSL versions 1.0.2, 1.1.1 and 3.0. It was addressed in the releases of 1.1.1n and 3.0.2 on the 15th March 2022. Fixed in OpenSSL 3.0.2 (Affected 3.0.0,3.0.1). Fixed in OpenSSL 1.1.1n (Affected 1.1.1-1.1.1m). Fixed in OpenSSL 1.0.2zd (Affected 1.0.2-1.0.2zc).",
+            "name": "CVE-2022-0778",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "openssl",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (1.1.1-1ubuntu2.1~18.04.15)"
+                            ],
+                            [
+                                "focal",
+                                "Released (1.1.1f-1ubuntu2.12)"
+                            ],
+                            [
+                                "impish",
+                                "Released (1.1.1l-1ubuntu1.2)"
+                            ],
+                            [
+                                "trusty",
+                                "Released (1.0.1f-1ubuntu2.27+esm5)"
+                            ],
+                            [
+                                "upstream",
+                                "Released (1.1.1n,3.0.2)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (1.0.2g-1ubuntu4.20+esm2)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "HIGH",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-0778"
         }
     ],
     "p11-kit": [
         {
-            "name": "CVE-2020-29361",
-            "description": "An issue was discovered in p11-kit 0.21.1 through 0.23.21. Multiple integer overflows have been discovered in the array allocations in the p11-kit library and the p11-kit list command, where overflow checks are missing before calling realloc or calloc.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-29361",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -4853,8 +6375,11 @@
                     "value": "5"
                 }
             ],
+            "description": "An issue was discovered in p11-kit 0.21.1 through 0.23.21. Multiple integer overflows have been discovered in the array allocations in the p11-kit library and the p11-kit list command, where overflow checks are missing before calling realloc or calloc.",
+            "name": "CVE-2020-29361",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "p11-kit",
@@ -4864,40 +6389,45 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (0.23.22-1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (0.23.20-1ubuntu0.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (0.23.9-2ubuntu0.1)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (0.23.2-5~ubuntu16.04.2)"
+                                "focal",
+                                "Released (0.23.20-1ubuntu0.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (0.23.21-2ubuntu0.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (0.23.22-1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needs-triage)"
+                            ],
+                            [
+                                "trusty",
                                 "Released (0.20.2-2ubuntu2+esm1)"
                             ],
                             [
-                                "Patches:",
-                                "Upstream: Upstream:"
+                                "upstream",
+                                "Released (0.23.22-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (0.23.2-5~ubuntu16.04.2)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-29361"
         },
         {
-            "name": "CVE-2020-29362",
-            "description": "An issue was discovered in p11-kit 0.21.1 through 0.23.21. A heap-based buffer over-read has been discovered in the RPC protocol used by thep11-kit server/remote commands and the client library. When the remote entity supplies a byte array through a serialized PKCS#11 function call, the receiving entity may allow the reading of up to 4 bytes of memory past the heap allocation.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-29362",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -4916,8 +6446,11 @@
                     "value": "5"
                 }
             ],
+            "description": "An issue was discovered in p11-kit 0.21.1 through 0.23.21. A heap-based buffer over-read has been discovered in the RPC protocol used by thep11-kit server/remote commands and the client library. When the remote entity supplies a byte array through a serialized PKCS#11 function call, the receiving entity may allow the reading of up to 4 bytes of memory past the heap allocation.",
+            "name": "CVE-2020-29362",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "p11-kit",
@@ -4927,46 +6460,51 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Released (0.23.22-1)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (0.23.22-1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (0.23.20-1ubuntu0.1)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (0.23.9-2ubuntu0.1)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (0.23.2-5~ubuntu16.04.2)"
+                                "focal",
+                                "Released (0.23.20-1ubuntu0.1)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (0.23.21-2ubuntu0.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (0.23.22-1)"
+                            ],
+                            [
+                                "impish",
+                                "Released (0.23.22-1)"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needs-triage)"
+                            ],
+                            [
+                                "trusty",
                                 "Not vulnerable (code not present)"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
+                                "upstream",
+                                "Released (0.23.22-1)"
+                            ],
+                            [
+                                "xenial",
+                                "Released (0.23.2-5~ubuntu16.04.2)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-29362"
         }
     ],
     "perl": [
         {
-            "name": "CVE-2020-16156",
-            "description": "CPAN 2.28 allows Signature Verification Bypass.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-16156",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -4985,8 +6523,13 @@
                     "value": "6.8"
                 }
             ],
+            "description": "CPAN 2.28 allows Signature Verification Bypass.",
+            "name": "CVE-2020-16156",
             "scraped_data": [
                 {
+                    "notes": [
+                        "Fix is in cpanpm 2.29"
+                    ],
                     "status_table": {
                         "packages": [
                             "perl",
@@ -4996,44 +6539,169 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
+                                "bionic",
                                 "Needed"
                             ],
                             [
-                                "Ubuntu 21.10 (Impish Indri)",
+                                "focal",
                                 "Needed"
                             ],
                             [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
                                 "Needed"
                             ],
                             [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "trusty",
                                 "Needed"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "upstream",
                                 "Needed"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "xenial",
                                 "Needed"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "Fix is in cpanpm 2.29"
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-16156"
+        }
+    ],
+    "python2.7": [
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.7.12-1ubuntu0~16.04.18"
+                },
+                {
+                    "key": "package_name",
+                    "value": "python2.7"
+                }
+            ],
+            "description": "[ftplib should not use the host from the PASV response]",
+            "name": "CVE-2021-4189",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "python2.7",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.7.17-1~18.04ubuntu1.7)"
+                            ],
+                            [
+                                "focal",
+                                "Needs triage"
+                            ],
+                            [
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
+                                "Needs triage"
+                            ],
+                            [
+                                "trusty",
+                                "Needs triage"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.7.12-1ubuntu0~16.04.18+esm1)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-4189"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "2.7.12-1ubuntu0~16.04.18"
+                },
+                {
+                    "key": "package_name",
+                    "value": "python2.7"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:P/A:N"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "description": "A flaw was found in Python, specifically within the urllib.parse module. This module helps break Uniform Resource Locator (URL) strings into components. The issue involves how the urlparse method does not sanitize input and allows characters like '\\r' and '\\n' in the URL path. This flaw allows an attacker to input a crafted URL, leading to injection attacks. This flaw affects Python versions prior to 3.10.0b1, 3.9.5, 3.8.11, 3.7.11 and 3.6.14.",
+            "name": "CVE-2022-0391",
+            "scraped_data": [
+                {
+                    "notes": [
+                        "for python2.7 code affected, urlsplit is in Lib/urlparse.py.\naccording with Debian, the fix for python3.5 causes regressions."
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "python2.7",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (2.7.17-1~18.04ubuntu1.7)"
+                            ],
+                            [
+                                "focal",
+                                "Needs triage"
+                            ],
+                            [
+                                "impish",
+                                "Needs triage"
+                            ],
+                            [
+                                "trusty",
+                                "Needs triage"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (2.7.12-1ubuntu0~16.04.18+esm1)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-0391"
         }
     ],
     "python3.5": [
         {
-            "name": "CVE-2021-3733",
-            "description": "[Denial of service when identifying crafted invalid RFCs]",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3733",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -5042,67 +6710,23 @@
                 {
                     "key": "package_name",
                     "value": "python3.5"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:S/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "4"
                 }
             ],
+            "description": "There's a flaw in urllib's AbstractBasicAuthHandler class. An attacker who controls a malicious HTTP server that an HTTP client (such as web browser) connects to, could trigger a Regular Expression Denial of Service (ReDOS) during an authentication request with a specially crafted payload that is sent by the server to the client. The greatest threat that this flaw poses is to application availability.",
+            "name": "CVE-2021-3733",
             "scraped_data": [
                 {
-                    "status_table": {
-                        "packages": [
-                            "python3.5",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Does not exist"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Does not exist"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Does not exist"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (3.5.2-2ubuntu0~16.04.13+esm1)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ]
-                        ]
-                    },
                     "notes": [
                         "code affected in hirsute and devel is already patched, so both releases\nin python3.9 are not affected."
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "CVE-2021-3737",
-            "description": "[client can enter an infinite loop on a 100 Continue response from the server]",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3737",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "3.5.2-2ubuntu0~16.04.13"
-                },
-                {
-                    "key": "package_name",
-                    "value": "python3.5"
-                }
-            ],
-            "scraped_data": [
-                {
+                    ],
                     "status_table": {
                         "packages": [
                             "python3.5",
@@ -5112,42 +6736,110 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
+                                "bionic",
+                                "Does not exist"
+                            ],
+                            [
+                                "focal",
+                                "Does not exist"
+                            ],
+                            [
+                                "hirsute",
+                                "Does not exist"
+                            ],
+                            [
+                                "impish",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
+                                "Needed"
+                            ],
+                            [
+                                "upstream",
                                 "Needs triage"
                             ],
                             [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Does not exist"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Does not exist"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Does not exist"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "xenial",
                                 "Released (3.5.2-2ubuntu0~16.04.13+esm1)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "impish/devel is not affected, code supposed affected was patched already."
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3733"
         },
         {
-            "name": "CVE-2021-4189",
-            "description": "[ftplib should not use the host from the PASV response]",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-4189",
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "3.5.2-2ubuntu0~16.04.13"
+                },
+                {
+                    "key": "package_name",
+                    "value": "python3.5"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:C"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "7.1"
+                }
+            ],
+            "description": "A flaw was found in python. An improperly handled HTTP response in the HTTP client code of python may allow a remote attacker, who controls the HTTP server, to make the client script enter an infinite loop, consuming CPU time. The highest threat from this vulnerability is to system availability.",
+            "name": "CVE-2021-3737",
+            "scraped_data": [
+                {
+                    "notes": [
+                        "impish/devel is not affected, code supposed affected was patched already."
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "python3.5",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Does not exist"
+                            ],
+                            [
+                                "focal",
+                                "Does not exist"
+                            ],
+                            [
+                                "hirsute",
+                                "Does not exist"
+                            ],
+                            [
+                                "impish",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
+                                "Needed"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (3.5.2-2ubuntu0~16.04.13+esm1)"
+                            ]
+                        ]
+                    }
+                }
+            ],
             "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3737"
+        },
+        {
             "attributes": [
                 {
                     "key": "package_version",
@@ -5158,8 +6850,11 @@
                     "value": "python3.5"
                 }
             ],
+            "description": "[ftplib should not use the host from the PASV response]",
+            "name": "CVE-2021-4189",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "python3.5",
@@ -5169,42 +6864,177 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
+                                "bionic",
                                 "Does not exist"
                             ],
                             [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
+                                "focal",
                                 "Does not exist"
                             ],
                             [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "hirsute",
                                 "Does not exist"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
+                                "impish",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
                                 "Needed"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "upstream",
                                 "Needed"
+                            ],
+                            [
+                                "xenial",
+                                "Released (3.5.2-2ubuntu0~16.04.13+esm2)"
                             ]
                         ]
-                    },
-                    "notes": []
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-4189"
+        },
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "3.5.2-2ubuntu0~16.04.13"
+                },
+                {
+                    "key": "package_name",
+                    "value": "python3.5"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:L/Au:N/C:N/I:P/A:N"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "5"
+                }
+            ],
+            "description": "A flaw was found in Python, specifically within the urllib.parse module. This module helps break Uniform Resource Locator (URL) strings into components. The issue involves how the urlparse method does not sanitize input and allows characters like '\\r' and '\\n' in the URL path. This flaw allows an attacker to input a crafted URL, leading to injection attacks. This flaw affects Python versions prior to 3.10.0b1, 3.9.5, 3.8.11, 3.7.11 and 3.6.14.",
+            "name": "CVE-2022-0391",
+            "scraped_data": [
+                {
+                    "notes": [
+                        "for python2.7 code affected, urlsplit is in Lib/urlparse.py.\naccording with Debian, the fix for python3.5 causes regressions."
+                    ],
+                    "status_table": {
+                        "packages": [
+                            "python3.5",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Does not exist"
+                            ],
+                            [
+                                "focal",
+                                "Does not exist"
+                            ],
+                            [
+                                "impish",
+                                "Does not exist"
+                            ],
+                            [
+                                "trusty",
+                                "Needs triage"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (3.5.2-2ubuntu0~16.04.13+esm2)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-0391"
+        }
+    ],
+    "speex": [
+        {
+            "attributes": [
+                {
+                    "key": "package_version",
+                    "value": "1.2~rc1.2-1ubuntu1"
+                },
+                {
+                    "key": "package_name",
+                    "value": "speex"
+                },
+                {
+                    "key": "CVSS2_VECTOR",
+                    "value": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+                },
+                {
+                    "key": "CVSS2_SCORE",
+                    "value": "4.3"
+                }
+            ],
+            "description": "A Divide by Zero vulnerability in the function static int read_samples of Speex v1.2 allows attackers to cause a denial of service (DoS) via a crafted WAV file.",
+            "name": "CVE-2020-23903",
+            "scraped_data": [
+                {
+                    "notes": [],
+                    "status_table": {
+                        "packages": [
+                            "speex",
+                            "Launchpad",
+                            "Ubuntu",
+                            "Debian"
+                        ],
+                        "release_states": [
+                            [
+                                "bionic",
+                                "Released (1.2~rc1.2-1ubuntu2.1)"
+                            ],
+                            [
+                                "focal",
+                                "Released (1.2~rc1.2-1.1ubuntu1.20.04.1)"
+                            ],
+                            [
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
+                                "Released (1.2~rc1.2-1.1ubuntu1.21.10.1)"
+                            ],
+                            [
+                                "trusty",
+                                "Ignored (out of standard support)"
+                            ],
+                            [
+                                "upstream",
+                                "Needs triage"
+                            ],
+                            [
+                                "xenial",
+                                "Released (1.2~rc1.2-1ubuntu1+esm1)"
+                            ]
+                        ]
+                    }
+                }
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-23903"
         }
     ],
     "sqlite3": [
         {
-            "name": "CVE-2020-9794",
-            "description": "An out-of-bounds read was addressed with improved bounds checking. This issue is fixed in iOS 13.5 and iPadOS 13.5, macOS Catalina 10.15.5, tvOS 13.4.5, watchOS 6.2.5, iTunes 12.10.7 for Windows, iCloud for Windows 11.2, iCloud for Windows 7.19. A malicious application may cause a denial of service or potentially disclose memory contents.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-9794",
-            "severity": "MEDIUM",
             "attributes": [
                 {
                     "key": "package_version",
@@ -5223,8 +7053,13 @@
                     "value": "5.8"
                 }
             ],
+            "description": "An out-of-bounds read was addressed with improved bounds checking. This issue is fixed in iOS 13.5 and iPadOS 13.5, macOS Catalina 10.15.5, tvOS 13.4.5, watchOS 6.2.5, iTunes 12.10.7 for Windows, iCloud for Windows 11.2, iCloud for Windows 7.19. A malicious application may cause a denial of service or potentially disclose memory contents.",
+            "name": "CVE-2020-9794",
             "scraped_data": [
                 {
+                    "notes": [
+                        "This may be an Apple-specific CVE, as of 2021-02-08, no details\nare available as to what the upstream fix is."
+                    ],
                     "status_table": {
                         "packages": [
                             "sqlite3",
@@ -5234,44 +7069,55 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
+                                "bionic",
+                                "Deferred"
+                            ],
+                            [
+                                "eoan",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "focal",
+                                "Deferred"
+                            ],
+                            [
+                                "groovy",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "hirsute",
+                                "Ignored (reached end-of-life)"
+                            ],
+                            [
+                                "impish",
+                                "Deferred"
+                            ],
+                            [
+                                "precise",
+                                "Ignored (end of ESM support, was needs-triage)"
+                            ],
+                            [
+                                "trusty",
+                                "Deferred"
+                            ],
+                            [
+                                "upstream",
                                 "Needs triage"
                             ],
                             [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Deferred"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Deferred"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Deferred"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Deferred"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "xenial",
                                 "Deferred"
                             ]
                         ]
-                    },
-                    "notes": [
-                        "This may be an Apple-specific CVE, as of 2021-02-08, no details\nare available as to what the upstream fix is."
-                    ]
+                    }
                 }
-            ]
+            ],
+            "severity": "MEDIUM",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-9794"
         }
     ],
     "systemd": [
         {
-            "name": "CVE-2021-33910",
-            "description": "basic/unit-name.c in systemd prior to 246.15, 247.8, 248.5, and 249.1 has a Memory Allocation with an Excessive Size Value (involving strdupa and alloca for a pathname controlled by a local attacker) that results in an operating system crash.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-33910",
-            "severity": "HIGH",
             "attributes": [
                 {
                     "key": "package_version",
@@ -5290,8 +7136,11 @@
                     "value": "4.9"
                 }
             ],
+            "description": "basic/unit-name.c in systemd prior to 246.15, 247.8, 248.5, and 249.1 has a Memory Allocation with an Excessive Size Value (involving strdupa and alloca for a pathname controlled by a local attacker) that results in an operating system crash.",
+            "name": "CVE-2021-33910",
             "scraped_data": [
                 {
+                    "notes": [],
                     "status_table": {
                         "packages": [
                             "systemd",
@@ -5301,733 +7150,43 @@
                         ],
                         "release_states": [
                             [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (248.3-1ubuntu3)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (245.4-4ubuntu3.10)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
+                                "bionic",
                                 "Released (237-3ubuntu10.49)"
                             ],
                             [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (229-4ubuntu21.31+esm1)"
+                                "focal",
+                                "Released (245.4-4ubuntu3.10)"
                             ],
                             [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
+                                "groovy",
+                                "Released (246.6-1ubuntu1.7)"
+                            ],
+                            [
+                                "hirsute",
+                                "Released (247.3-3ubuntu3.4)"
+                            ],
+                            [
+                                "impish",
+                                "Released (248.3-1ubuntu3)"
+                            ],
+                            [
+                                "trusty",
                                 "Not vulnerable"
                             ],
                             [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        }
-    ],
-    "vim": [
-        {
-            "name": "CVE-2021-3778",
-            "description": "vim is vulnerable to Heap-based Buffer Overflow",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3778",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "2:7.4.1689-3ubuntu1.5"
-                },
-                {
-                    "key": "package_name",
-                    "value": "vim"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "6.8"
-                }
-            ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "vim",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (v8.2.3409)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2:8.2.2434-3ubuntu2)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2:8.1.2269-1ubuntu5.3)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2:8.0.1453-1ubuntu1.6)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2:7.4.1689-3ubuntu1.5+esm2)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Released (2:7.4.052-1ubuntu3.1+esm3)"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2021-3796",
-            "description": "vim is vulnerable to Use After Free",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3796",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "2:7.4.1689-3ubuntu1.5"
-                },
-                {
-                    "key": "package_name",
-                    "value": "vim"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "6.8"
-                }
-            ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "vim",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (v8.2.3428)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2:8.2.2434-3ubuntu2)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2:8.1.2269-1ubuntu5.3)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2:8.0.1453-1ubuntu1.6)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2:7.4.1689-3ubuntu1.5+esm2)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Released (2:7.4.052-1ubuntu3.1+esm3)"
-                            ],
-                            [
-                                "Patches:",
-                                "Upstream:"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2021-3927",
-            "description": "vim is vulnerable to Heap-based Buffer Overflow",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3927",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "2:7.4.1689-3ubuntu1.5"
-                },
-                {
-                    "key": "package_name",
-                    "value": "vim"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "6.8"
-                }
-            ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "vim",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (v8.2.3581)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2:8.2.2434-3ubuntu3.1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2:8.1.2269-1ubuntu5.4)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2:8.0.1453-1ubuntu1.7)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2:7.4.1689-3ubuntu1.5+esm3)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Released (2:7.4.052-1ubuntu3.1+esm4)"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2021-3928",
-            "description": "vim is vulnerable to Use of Uninitialized Variable",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3928",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "2:7.4.1689-3ubuntu1.5"
-                },
-                {
-                    "key": "package_name",
-                    "value": "vim"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:L/AC:L/Au:N/C:P/I:P/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "4.6"
-                }
-            ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "vim",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (v8.2.3582)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2:8.2.2434-3ubuntu3.1)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2:8.1.2269-1ubuntu5.4)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2:8.0.1453-1ubuntu1.7)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Released (2:7.4.1689-3ubuntu1.5+esm3)"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Released (2:7.4.052-1ubuntu3.1+esm4)"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2021-3984",
-            "description": "vim is vulnerable to Heap-based Buffer Overflow",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-3984",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "2:7.4.1689-3ubuntu1.5"
-                },
-                {
-                    "key": "package_name",
-                    "value": "vim"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "6.8"
-                }
-            ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "vim",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (v8.2.3625)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2:8.2.2434-3ubuntu3.2)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2:8.1.2269-1ubuntu5.6)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2:8.0.1453-1ubuntu1.8)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ]
-                        ]
-                    },
-                    "notes": [
-                        "for bionic and earlier, the vulnerable function in src/cindent.c\nis in src/misc1.c."
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "CVE-2021-4019",
-            "description": "vim is vulnerable to Heap-based Buffer Overflow",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-4019",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "2:7.4.1689-3ubuntu1.5"
-                },
-                {
-                    "key": "package_name",
-                    "value": "vim"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "6.8"
-                }
-            ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "vim",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (v8.2.3669)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2:8.2.2434-3ubuntu3.2)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2:8.1.2269-1ubuntu5.6)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2:8.0.1453-1ubuntu1.8)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ]
-                        ]
-                    },
-                    "notes": [
-                        "in focal and earlier vulnerable function from src/help.c\nis in src/ex_cmds.c."
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "CVE-2021-4069",
-            "description": "vim is vulnerable to Use After Free",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-4069",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "2:7.4.1689-3ubuntu1.5"
-                },
-                {
-                    "key": "package_name",
-                    "value": "vim"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "6.8"
-                }
-            ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "vim",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Released (v8.2.3761)"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Released (2:8.2.2434-3ubuntu3.2)"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Released (2:8.1.2269-1ubuntu5.6)"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Released (2:8.0.1453-1ubuntu1.8)"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2022-0351",
-            "description": "Access of Memory Location Before Start of Buffer in Conda vim prior to 8.2.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-0351",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "2:7.4.1689-3ubuntu1.5"
-                },
-                {
-                    "key": "package_name",
-                    "value": "vim"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:L/AC:L/Au:N/C:P/I:P/A:P"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "4.6"
-                }
-            ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "vim",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
+                                "upstream",
                                 "Needs triage"
                             ],
                             [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
+                                "xenial",
+                                "Released (229-4ubuntu21.31+esm1)"
                             ]
                         ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2022-0359",
-            "description": "Heap-based Buffer Overflow in Conda vim prior to 8.2.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-0359",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "2:7.4.1689-3ubuntu1.5"
-                },
-                {
-                    "key": "package_name",
-                    "value": "vim"
+                    }
                 }
             ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "vim",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        },
-        {
-            "name": "CVE-2022-0361",
-            "description": "Heap-based Buffer Overflow in Conda vim prior to 8.2.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-0361",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "2:7.4.1689-3ubuntu1.5"
-                },
-                {
-                    "key": "package_name",
-                    "value": "vim"
-                }
-            ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "vim",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Needed"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Needed"
-                            ]
-                        ]
-                    },
-                    "notes": []
-                }
-            ]
-        }
-    ],
-    "wget": [
-        {
-            "name": "CVE-2021-31879",
-            "description": "GNU Wget through 1.21.1 does not omit the Authorization header upon a redirect to a different origin, a related issue to CVE-2018-1000007.",
-            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-31879",
-            "severity": "MEDIUM",
-            "attributes": [
-                {
-                    "key": "package_version",
-                    "value": "1.17.1-1ubuntu1.5"
-                },
-                {
-                    "key": "package_name",
-                    "value": "wget"
-                },
-                {
-                    "key": "CVSS2_VECTOR",
-                    "value": "AV:N/AC:M/Au:N/C:P/I:P/A:N"
-                },
-                {
-                    "key": "CVSS2_SCORE",
-                    "value": "5.8"
-                }
-            ],
-            "scraped_data": [
-                {
-                    "status_table": {
-                        "packages": [
-                            "wget",
-                            "Launchpad",
-                            "Ubuntu",
-                            "Debian"
-                        ],
-                        "release_states": [
-                            [
-                                "Upstream",
-                                "Needs triage"
-                            ],
-                            [
-                                "Ubuntu 21.10 (Impish Indri)",
-                                "Deferred"
-                            ],
-                            [
-                                "Ubuntu 20.04 LTS (Focal Fossa)",
-                                "Deferred"
-                            ],
-                            [
-                                "Ubuntu 18.04 LTS (Bionic Beaver)",
-                                "Deferred"
-                            ],
-                            [
-                                "Ubuntu 16.04 ESM (Xenial Xerus)",
-                                "Deferred"
-                            ],
-                            [
-                                "Ubuntu 14.04 ESM (Trusty Tahr)",
-                                "Deferred"
-                            ]
-                        ]
-                    },
-                    "notes": [
-                        "no upstream fix as of 2022-01-05\nalso see previous upstream bug from 2019"
-                    ]
-                }
-            ]
+            "severity": "HIGH",
+            "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2021-33910"
         }
     ]
 }

--- a/mxnet/inference/docker/1.8/py3/cu110/apt-upgrade-list-gpu.txt
+++ b/mxnet/inference/docker/1.8/py3/cu110/apt-upgrade-list-gpu.txt
@@ -1,0 +1,3 @@
+vim
+libc6
+wget


### PR DESCRIPTION
Total vulnerabilites that can be fixed 3
Total vulnerabilites that can NOT be fixed 10


Fixable vulnerabilites:

```
glibc | 2.23-0ubuntu11.2 | CVE-2021-38604 | MEDIUM
glibc | 2.23-0ubuntu11.3 | CVE-2021-38604 | MEDIUM
vim | 2:7.4.1689-3ubuntu1.5 | CVE-2021-3778 | MEDIUM
vim | 2:7.4.1689-3ubuntu1.5 | CVE-2021-3796 | MEDIUM
vim | 2:7.4.1689-3ubuntu1.5 | CVE-2021-3927 | MEDIUM
vim | 2:7.4.1689-3ubuntu1.5 | CVE-2021-3928 | MEDIUM
vim | 2:7.4.1689-3ubuntu1.5 | CVE-2021-3984 | MEDIUM
vim | 2:7.4.1689-3ubuntu1.5 | CVE-2021-4019 | MEDIUM
vim | 2:7.4.1689-3ubuntu1.5 | CVE-2021-4069 | MEDIUM
vim | 2:7.4.1689-3ubuntu1.5 | CVE-2022-0351 | MEDIUM
vim | 2:7.4.1689-3ubuntu1.5 | CVE-2022-0359 | MEDIUM
vim | 2:7.4.1689-3ubuntu1.5 | CVE-2022-0361 | MEDIUM
wget | 1.17.1-1ubuntu1.5 | CVE-2021-31879 | MEDIUM
```

Non-Fixable vulnerabilites:

```
cyrus-sasl2 | 2.1.26.dfsg1-14ubuntu0.2 | CVE-2022-24407 | HIGH
expat | 2.1.0-7ubuntu0.16.04.5 | CVE-2022-25236 | HIGH
expat | 2.1.0-7ubuntu0.16.04.5 | CVE-2022-25235 | HIGH
expat | 2.1.0-7ubuntu0.16.04.5 | CVE-2022-22823 | MEDIUM
expat | 2.1.0-7ubuntu0.16.04.5 | CVE-2022-22822 | MEDIUM
expat | 2.1.0-7ubuntu0.16.04.5 | CVE-2022-22825 | MEDIUM
expat | 2.1.0-7ubuntu0.16.04.5 | CVE-2022-22824 | MEDIUM
expat | 2.1.0-7ubuntu0.16.04.5 | CVE-2022-22827 | MEDIUM
expat | 2.1.0-7ubuntu0.16.04.5 | CVE-2022-22826 | MEDIUM
expat | 2.1.0-7ubuntu0.16.04.5 | CVE-2022-25315 | MEDIUM
expat | 2.1.0-7ubuntu0.16.04.5 | CVE-2021-46143 | MEDIUM
expat | 2.1.0-7ubuntu0.16.04.5 | CVE-2022-25313 | MEDIUM
openssl | 1.0.2g-1ubuntu4.18 | CVE-2022-0778 | HIGH
openssl | 1.0.2g-1ubuntu4.20 | CVE-2022-0778 | HIGH
gdk-pixbuf | 2.32.2-1ubuntu1.6 | CVE-2021-44648 | MEDIUM
glibc | 2.23-0ubuntu11.2 | CVE-2021-3999 | MEDIUM
glibc | 2.23-0ubuntu11.3 | CVE-2021-3999 | MEDIUM
gzip | 1.6-4ubuntu1 | CVE-2022-1271 | MEDIUM
openexr | 2.2.0-10ubuntu2.6 | CVE-2021-3933 | MEDIUM
python2.7 | 2.7.12-1ubuntu0~16.04.18 | CVE-2021-4189 | MEDIUM
python2.7 | 2.7.12-1ubuntu0~16.04.18 | CVE-2022-0391 | MEDIUM
python3.5 | 3.5.2-2ubuntu0~16.04.13 | CVE-2022-0391 | MEDIUM
python3.5 | 3.5.2-2ubuntu0~16.04.13 | CVE-2021-3737 | MEDIUM
python3.5 | 3.5.2-2ubuntu0~16.04.13 | CVE-2021-3733 | MEDIUM
speex | 1.2~rc1.2-1ubuntu1 | CVE-2020-23903 | MEDIUM
```